### PR TITLE
Update for nullability changes in wire-ios-data-model

### DIFF
--- a/Source/Transcoders/FileUploadRequestStrategy.swift
+++ b/Source/Transcoders/FileUploadRequestStrategy.swift
@@ -138,8 +138,8 @@ private let reponseHeaderAssetIdKey = "Location"
     
     public func updateInsertedObject(_ managedObject: ZMManagedObject,request upstreamRequest: ZMUpstreamRequest,response: ZMTransportResponse)
     {
-        guard let message = managedObject as? ZMAssetClientMessage else { return }
-        message.update(withPostPayload: response.payload?.asDictionary(), updatedKeys: Set())
+        guard let message = managedObject as? ZMAssetClientMessage, let payload = response.payload?.asDictionary() else { return }
+        message.update(withPostPayload: payload, updatedKeys: Set())
         if let delegate = self.clientRegistrationStatus {
             _ = message.parseUploadResponse(response, clientDeletionDelegate: delegate)
         }

--- a/Source/Transcoders/ImageUploadRequestStrategy.swift
+++ b/Source/Transcoders/ImageUploadRequestStrategy.swift
@@ -80,8 +80,9 @@ extension ImageUploadRequestStrategy : ZMUpstreamTranscoder {
     
     fileprivate func update(_ message: ZMAssetClientMessage, withResponse response: ZMTransportResponse, updatedKeys keys: Set<String>) {
         message.markAsSent()
-        message.update(withPostPayload: response.payload?.asDictionary(), updatedKeys: keys)
-        
+        guard let payload = response.payload?.asDictionary() else { return }
+        message.update(withPostPayload: payload, updatedKeys: keys)
+
         if let clientRegistrationStatus = self.clientRegistrationStatus {
             let _ = message.parseUploadResponse(response, clientDeletionDelegate: clientRegistrationStatus)
         }


### PR DESCRIPTION
# What's in this PR?

* The nullability of some parameters was changed in https://github.com/wireapp/wire-ios-data-model/pull/66, this PR updates the message strategy framework accordingly.