### PR TITLE
Add initial logic to download assets from the v3 endpoint

### DIFF
--- a/Source/Transcoders/AssetDownloadRequestStrategy.swift
+++ b/Source/Transcoders/AssetDownloadRequestStrategy.swift
@@ -45,6 +45,8 @@ import ZMTransport
         let filter = NSPredicate { object, _ in
             guard let message = object as? ZMAssetClientMessage else { return false }
             guard message.fileMessageData != nil else { return false }
+
+            // V2
             if message.assetId != nil {
                 return true
             }

--- a/Source/Transcoders/LinkPreviewAssetDownloadRequestStrategy.swift
+++ b/Source/Transcoders/LinkPreviewAssetDownloadRequestStrategy.swift
@@ -140,9 +140,9 @@ extension LinkPreviewAssetDownloadRequestStrategy: ZMDownstreamTranscoder {
 
 extension ZMLinkPreview {
     var remote: ZMAssetRemoteData? {
-        if let image = article.image , image.hasUploaded() {
+        if let image = article.image, image.hasUploaded() {
             return image.uploaded
-        } else if let image = image , hasImage() {
+        } else if let image = image, hasImage() {
             return image.uploaded
         }
         

--- a/Tests/Source/AssetDownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetDownloadRequestStrategyTests.swift
@@ -60,22 +60,53 @@ class AssetDownloadRequestStrategyTests: MessagingTest {
     fileprivate func createFileTransferMessage(_ conversation: ZMConversation) -> ZMAssetClientMessage {
         let message = conversation.appendMessage(with: ZMFileMetadata(fileURL: testDataURL)) as! ZMAssetClientMessage
         message.assetId = UUID.create()
+        prepare(message: message)
+        return message
+    }
+
+    fileprivate func createFileMessageWithAssetId(
+        in conversation: ZMConversation,
+        otrKey: Data = Data.randomEncryptionKey(),
+        sha: Data  = Data.randomEncryptionKey()
+        ) -> (message: ZMAssetClientMessage, assetId: String, assetToken: String)? {
+
+        let message = conversation.appendMessage(with: ZMFileMetadata(fileURL: testDataURL)) as! ZMAssetClientMessage
+
+        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+
+        // TODO: We should replace this manual update with inserting a v3 asset as soon as we have sending support
+        let uploaded = ZMGenericMessage.genericMessage(
+            withUploadedOTRKey: otrKey,
+            sha256: sha,
+            messageID: message.nonce.transportString(),
+            expiresAfter: NSNumber(value: conversation.messageDestructionTimeout)
+        )
+
+        guard let uploadedWithId = uploaded.updated(withAssetId: assetId, token: token) else {
+            XCTFail("Failed to update asset")
+            return nil
+        }
+
+        message.add(uploadedWithId)
+        prepare(message: message)
+        return (message, assetId, token)
+    }
+
+    fileprivate func prepare(message: ZMAssetClientMessage) {
         message.fileMessageData?.transferState = .downloading
-        
         self.syncMOC.saveOrRollback()
-        
+
         self.sut.contextChangeTrackers.forEach { tracker in
             tracker.objectsDidChange(Set(arrayLiteral: message))
         }
-        
+
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        return message
     }
 }
 
 // request generation tests
 extension AssetDownloadRequestStrategyTests {
+
     func testThatItGeneratesNoRequestsIfTheStatusIsEmpty() {
         XCTAssertNil(self.sut.nextRequest())
     }
@@ -167,10 +198,12 @@ extension AssetDownloadRequestStrategyTests {
         XCTAssertNil(request2)
         
     }
+
 }
 
 // tests on result of request
 extension AssetDownloadRequestStrategyTests {
+
     func testThatItMarksDownloadAsSuccessIfSuccessfulDownloadAndDecryption() {
         
         // given
@@ -442,3 +475,238 @@ extension AssetDownloadRequestStrategyTests {
     }
 
 }
+
+
+// MARK: - Asset V3
+
+// V3 download request generation
+
+extension AssetDownloadRequestStrategyTests {
+
+    func testThatItGeneratesARequestToTheV3EndpointITheProtobufContainsAnAssetID_V3() {
+        // Given
+        guard let (message, assetId, token) = createFileMessageWithAssetId(in: createConversation()) else { return XCTFail("No message") }
+
+        guard let assetData = message.genericAssetMessage?.assetData else { return XCTFail("No assetData found") }
+        XCTAssert(assetData.hasUploaded())
+        XCTAssertEqual(assetData.uploaded.assetId, assetId)
+        XCTAssertEqual(assetData.uploaded.assetToken, token)
+
+        // When
+        guard let request = sut.nextRequest() else { return XCTFail("No request generated") }
+
+        // Then
+        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.path, "/assets/v3/\(assetId)")
+        XCTAssert(request.needsAuthentication)
+    }
+
+    func testThatItGeneratesARequestToTheV3EndpointITheProtobufContainsAnAssetID_EphemeralConversation_V3() {
+        // Given
+        let conversation = createConversation()
+        conversation.messageDestructionTimeout = 5
+        guard let (message, assetId, token) = createFileMessageWithAssetId(in: conversation) else { return XCTFail("No message") }
+
+        guard let assetData = message.genericAssetMessage?.assetData else { return XCTFail("No assetData found") }
+        XCTAssert(assetData.hasUploaded())
+        XCTAssertEqual(assetData.uploaded.assetId, assetId)
+        XCTAssertEqual(assetData.uploaded.assetToken, token)
+        XCTAssert(message.genericAssetMessage!.hasEphemeral())
+
+        // When
+        guard let request = sut.nextRequest() else { return XCTFail("No request generated") }
+
+        // Then
+        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.path, "/assets/v3/\(assetId)")
+        XCTAssert(request.needsAuthentication)
+    }
+
+    func testThatItGeneratesARequestOnlyOnceForAssetMessages_V3() {
+        // Given
+        guard let _ = createFileMessageWithAssetId(in: createConversation()) else { return XCTFail("No message") }
+
+        // When
+        guard let _ = sut.nextRequest() else { return XCTFail("No request generated") }
+
+        // Then
+        XCTAssertNil(sut.nextRequest())
+    }
+
+    func testThatItGeneratesNoRequestsIfNotAuthenticated_V3() {
+        // given
+        authStatus.mockClientIsReadyForRequests = false
+        _ = createFileMessageWithAssetId(in: conversation)! // V3
+
+        // then
+        XCTAssertNil(sut.nextRequest())
+    }
+
+    func testThatItGeneratesNoRequestsIfMessageIsUploading_V3() {
+        // given
+        guard let (message , _, _) = createFileMessageWithAssetId(in: conversation) else { return XCTFail() } // V3
+        message.fileMessageData?.transferState = .uploaded
+        syncMOC.saveOrRollback()
+
+        sut.contextChangeTrackers.forEach { tracker in
+            tracker.objectsDidChange(Set(arrayLiteral: message))
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertNil(sut.nextRequest())
+    }
+    
+}
+
+// tests on result of request
+extension AssetDownloadRequestStrategyTests {
+
+    func testThatItMarksDownloadAsSuccessIfSuccessfulDownloadAndDecryption_V3() {
+        // given
+        let plainTextData = Data.secureRandomData(length: 500)
+        let key = Data.randomEncryptionKey()
+        let encryptedData = plainTextData.zmEncryptPrefixingPlainTextIV(key: key)
+        let sha = encryptedData.zmSHA256Digest()
+
+        let (message, _, _) = createFileMessageWithAssetId(in: conversation, otrKey: key, sha: sha)!
+
+        let request = sut.nextRequest()
+        let response = ZMTransportResponse(imageData: encryptedData, httpStatus: 200, transportSessionError: .none, headers: [:])
+
+        // when
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(message.fileMessageData?.transferState.rawValue, ZMFileTransferState.downloaded.rawValue)
+    }
+
+    func testThatItMarksDownloadAsFailedIfCannotDownload_PermanentError_V3() {
+        // given
+        let (message, _, _) = createFileMessageWithAssetId(in: conversation)!
+        let request = sut.nextRequest()
+        let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 404, transportSessionError: .none)
+
+        // when
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(message.fileMessageData?.transferState.rawValue, ZMFileTransferState.failedDownload.rawValue)
+    }
+
+    func testThatItMarksDownloadAsFailedIfCannotDownload_TemporaryError_V3() {
+        // given
+        let (message, _, _) = createFileMessageWithAssetId(in: conversation)!
+        let request = sut.nextRequest()
+        let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 500, transportSessionError: .none)
+
+        // when
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(message.fileMessageData?.transferState.rawValue, ZMFileTransferState.failedDownload.rawValue)
+    }
+
+    func testThatItMarksDownloadAsFailedIfCannotDownload_CannotDecrypt_V3() {
+        // given
+        let (message, _, _) = createFileMessageWithAssetId(in: conversation)!
+        let request = sut.nextRequest()
+        let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 200, transportSessionError: .none)
+
+        // when
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(message.fileMessageData?.transferState.rawValue, ZMFileTransferState.failedDownload.rawValue)
+    }
+
+    func testThatItDoesNotMarkDownloadAsFailedWhenNotDownloading_V3() {
+        // given
+        let (message, _, _) = createFileMessageWithAssetId(in: conversation)!
+        let request = sut.nextRequest()
+        let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 500, transportSessionError: .none)
+
+        // when
+        message.transferState = .uploaded
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(message.fileMessageData?.transferState.rawValue, ZMFileTransferState.uploaded.rawValue)
+    }
+
+    func testThatItUpdatesFileDownloadProgress_V3() {
+        // given
+        let expectedProgress: Float = 0.5
+        let (message, _, _) = createFileMessageWithAssetId(in: conversation)!
+        let request = sut.nextRequest()
+
+        XCTAssertEqual(message.fileMessageData?.progress, 0)
+
+        // when
+        request?.updateProgress(expectedProgress)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(message.fileMessageData?.progress, expectedProgress)
+    }
+
+    func testThatItSendsTheNotificationIfSuccessfulDownloadAndDecryption_V3() {
+
+        // given
+        let plainTextData = Data.secureRandomData(length: 500)
+        let key = Data.randomEncryptionKey()
+        let encryptedData = plainTextData.zmEncryptPrefixingPlainTextIV(key: key)
+        let sha = encryptedData.zmSHA256Digest()
+
+        let _ = createFileMessageWithAssetId(in: conversation, otrKey: key, sha: sha)!
+
+        let notificationExpectation = self.expectation(description: "Notification fired")
+
+        let _ = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: AssetDownloadRequestStrategyNotification.downloadFinishedNotificationName), object: nil, queue: .main) { notification in
+            XCTAssertNotNil(notification.userInfo![AssetDownloadRequestStrategyNotification.downloadStartTimestampKey])
+            notificationExpectation.fulfill()
+        }
+
+        let request = sut.nextRequest()
+        request?.markStartOfUploadTimestamp()
+        let response = ZMTransportResponse(imageData: encryptedData, httpStatus: 200, transportSessionError: .none, headers: [:])
+
+        // when
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+
+    }
+
+    func testThatItSendsTheNotificationIfCannotDownload_V3() {
+        // given
+
+        let notificationExpectation = self.expectation(description: "Notification fired")
+
+        let _ = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: AssetDownloadRequestStrategyNotification.downloadFailedNotificationName), object: nil, queue: .main) { notification in
+            XCTAssertNotNil(notification.userInfo![AssetDownloadRequestStrategyNotification.downloadStartTimestampKey])
+            notificationExpectation.fulfill()
+        }
+
+        let _ = createFileMessageWithAssetId(in: conversation)!
+        let request = sut.nextRequest()
+        request?.markStartOfUploadTimestamp()
+        let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 404, transportSessionError: .none)
+
+        // when
+        request?.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+}
+

--- a/Tests/Source/AssetDownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetDownloadRequestStrategyTests.swift
@@ -60,7 +60,7 @@ class AssetDownloadRequestStrategyTests: MessagingTest {
     fileprivate func createFileTransferMessage(_ conversation: ZMConversation) -> ZMAssetClientMessage {
         let message = conversation.appendMessage(with: ZMFileMetadata(fileURL: testDataURL)) as! ZMAssetClientMessage
         message.assetId = UUID.create()
-        prepare(message: message)
+        configureForDownloading(message: message)
         return message
     }
 
@@ -88,11 +88,11 @@ class AssetDownloadRequestStrategyTests: MessagingTest {
         }
 
         message.add(uploadedWithId)
-        prepare(message: message)
+        configureForDownloading(message: message)
         return (message, assetId, token)
     }
 
-    fileprivate func prepare(message: ZMAssetClientMessage) {
+    fileprivate func configureForDownloading(message: ZMAssetClientMessage) {
         message.fileMessageData?.transferState = .downloading
         self.syncMOC.saveOrRollback()
 


### PR DESCRIPTION
# What's in this PR?

* Add logic to `AssetDownloadRequestStrategy` to download an asset from the `v3` endpoint.
* We distinguish between v3 and v2 assets by inspecting the `ZMAssetRemoteData` in the genericMessage, if we have an assetId inside the protobuf we are dealing with a v3 asset and want to download it from the new endpoint.
* Added additional tests and ported existing tests to work with v3 assets as well.