### PR TITLE
Add strategy to download asset /v3 file previews

### DIFF
--- a/Source/Transcoders/AssetDownloadRequestStrategy.swift
+++ b/Source/Transcoders/AssetDownloadRequestStrategy.swift
@@ -104,9 +104,11 @@ import ZMTransport
             let fileCache = self.managedObjectContext.zm_fileAssetCache
             fileCache.storeAssetData(assetClientMessage.nonce, fileName: fileMessageData.filename, encrypted: true, data: response.rawData!)
 
+            let cacheKeySuffix: String = assetClientMessage.version == 3 ? asset.uploaded.assetId : fileMessageData.filename
+
             let decryptionSuccess = fileCache.decryptFileIfItMatchesDigest(
                 assetClientMessage.nonce,
-                fileName: fileMessageData.filename,
+                fileName: cacheKeySuffix,
                 encryptionKey: asset.uploaded.otrKey,
                 sha256Digest: asset.uploaded.sha256
             )

--- a/Source/Transcoders/AssetDownloadRequestStrategy.swift
+++ b/Source/Transcoders/AssetDownloadRequestStrategy.swift
@@ -52,7 +52,7 @@ import ZMTransport
             }
 
             // V3
-            guard let asset = message.genericAssetMessage?.assetData else { return false }
+            guard message.version == 3, let asset = message.genericAssetMessage?.assetData else { return false }
             return asset.hasUploaded() && asset.uploaded.hasAssetId()
         }
         
@@ -169,9 +169,7 @@ import ZMTransport
                 return request
             }
 
-            // If we have an asset ID in the protobuf then this message has been sent using the v3 endpoint
-            // and we need to create a request to get it from there (including a token if there is one)
-            if let asset = assetClientMessage.genericAssetMessage?.assetData, asset.uploaded.hasAssetId() {
+            if assetClientMessage.version == 3, let asset = assetClientMessage.genericAssetMessage?.assetData {
                 let token = asset.uploaded.hasAssetToken() ? asset.uploaded.assetToken : nil
                 if let request = AssetDownloadRequestFactory().requestToGetAsset(withKey: asset.uploaded.assetId, token: token) {
                     return addingHandlers(request)

--- a/Source/Transcoders/AssetV3PreviewDownloadStrategy.swift
+++ b/Source/Transcoders/AssetV3PreviewDownloadStrategy.swift
@@ -36,13 +36,13 @@ private let zmLog = ZMSLog(tag: "AssetPreviewDownloading")
         super.init()
 
         let downstreamPredicate = NSPredicate(
-            format: "transferState == %d AND visibleInConversation != nil",
+            format: "transferState == %d AND visibleInConversation != nil AND version == 3",
             ZMFileTransferState.downloading.rawValue
         )
 
         let filter = NSPredicate { object, _ in
             guard let message = object as? ZMAssetClientMessage, message.fileMessageData != nil else { return false }
-            guard message.version == 3, let asset = message.genericAssetMessage?.assetData else { return false }
+            guard let asset = message.genericAssetMessage?.assetData else { return false }
             return asset.preview.hasRemote() && asset.preview.remote.hasAssetId() && !message.hasDownloadedImage
         }
 

--- a/Source/Transcoders/AssetV3PreviewDownloadStrategy.swift
+++ b/Source/Transcoders/AssetV3PreviewDownloadStrategy.swift
@@ -1,0 +1,129 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import zimages
+import ZMTransport
+
+
+private let zmLog = ZMSLog(tag: "AssetPreviewDownloading")
+
+
+@objc public final class AssetV3PreviewDownloadRequestStrategy: NSObject, RequestStrategy, ZMContextChangeTrackerSource {
+
+    fileprivate var downstreamSync: ZMDownstreamObjectSync!
+    fileprivate let managedObjectContext: NSManagedObjectContext
+    fileprivate weak var authStatus: ClientRegistrationDelegate?
+
+    public init(authStatus: ClientRegistrationDelegate, managedObjectContext: NSManagedObjectContext) {
+        self.managedObjectContext = managedObjectContext
+        self.authStatus = authStatus
+        super.init()
+
+        let downstreamPredicate = NSPredicate(
+            format: "transferState == %d AND visibleInConversation != nil",
+            ZMFileTransferState.downloading.rawValue
+        )
+
+        let filter = NSPredicate { object, _ in
+            guard let message = object as? ZMAssetClientMessage, message.fileMessageData != nil else { return false }
+            guard message.version == 3, let asset = message.genericAssetMessage?.assetData else { return false }
+            return asset.preview.hasRemote() && asset.preview.remote.hasAssetId() && !message.hasDownloadedImage
+        }
+
+        downstreamSync = ZMDownstreamObjectSync(
+            transcoder: self,
+            entityName: ZMAssetClientMessage.entityName(),
+            predicateForObjectsToDownload: downstreamPredicate,
+            filter: filter,
+            managedObjectContext: managedObjectContext
+        )
+    }
+
+    public func nextRequest() -> ZMTransportRequest? {
+        guard let status = authStatus, status.clientIsReadyForRequests else { return nil }
+        return downstreamSync.nextRequest()
+    }
+
+    fileprivate func handleResponse(_ response: ZMTransportResponse, forMessage assetClientMessage: ZMAssetClientMessage) {
+        guard let asset = assetClientMessage.genericAssetMessage?.assetData, response.result == .success else { return }
+        guard let remote = asset.preview.remote, assetClientMessage.visibleInConversation != nil else { return }
+
+        let cache = managedObjectContext.zm_fileAssetCache
+        cache.storeAssetData(assetClientMessage.nonce, fileName: remote.assetId, encrypted: true, data: response.rawData!)
+
+        // Decrypt the preview image file
+        let success = cache.decryptFileIfItMatchesDigest(
+            assetClientMessage.nonce,
+            fileName: remote.assetId,
+            encryptionKey: remote.otrKey,
+            sha256Digest: remote.sha256
+        )
+
+        if !success {
+            zmLog.error("Unable to decrypt preview image for file message: \(assetClientMessage), \(asset)")
+        }
+
+        // Notify about the changes
+        let uiMOC = managedObjectContext.zm_userInterface
+
+        uiMOC?.performGroupedBlock {
+            guard let message = try? uiMOC?.existingObject(with: assetClientMessage.objectID) else { return }
+            uiMOC?.globalManagedObjectContextObserver.notifyNonCoreDataChangeInManagedObject(message!)
+        }
+    }
+
+    // MARK: - ZMContextChangeTrackerSource
+
+    public var contextChangeTrackers: [ZMContextChangeTracker] {
+        return [downstreamSync]
+    }
+
+}
+
+// MARK: - ZMDownstreamTranscoder
+
+extension AssetV3PreviewDownloadRequestStrategy: ZMDownstreamTranscoder {
+
+    public func request(forFetching object: ZMManagedObject!, downstreamSync: ZMObjectSync!) -> ZMTransportRequest! {
+        if let assetClientMessage = object as? ZMAssetClientMessage,
+            let asset = assetClientMessage.genericAssetMessage?.assetData,
+            let remote = asset.preview.remote,
+            assetClientMessage.version == 3 {
+
+            let token = remote.hasAssetToken() ? remote.assetToken : nil
+            if let request = AssetDownloadRequestFactory().requestToGetAsset(withKey: remote.assetId, token: token) {
+                request.add(ZMCompletionHandler(on: self.managedObjectContext) { response in
+                    self.handleResponse(response, forMessage: assetClientMessage)
+                })
+                return request
+            }
+        }
+
+        fatal("Cannot generate request to download v3 file preview for \(object)")
+    }
+
+    public func delete(_ object: ZMManagedObject!, downstreamSync: ZMObjectSync!) {
+        // no-op
+    }
+
+    public func update(_ object: ZMManagedObject!, with response: ZMTransportResponse!, downstreamSync: ZMObjectSync!) {
+        // no-op
+    }
+
+}

--- a/Source/Transcoders/ImageDownloadRequestStrategy.swift
+++ b/Source/Transcoders/ImageDownloadRequestStrategy.swift
@@ -31,6 +31,7 @@ public final class ImageDownloadRequestStrategy : ZMObjectSyncStrategy, RequestS
         
         let downloadPredicate = NSPredicate { (object, _) -> Bool in
             guard let message = object as? ZMAssetClientMessage else { return false }
+            guard message.version < 3 else { return false }
             let missingMediumImage = message.imageMessageData != nil && !message.hasDownloadedImage && message.assetId != nil
             let missingVideoThumbnail = message.fileMessageData != nil && !message.hasDownloadedImage && message.fileMessageData?.thumbnailAssetID != nil
             return missingMediumImage || missingVideoThumbnail

--- a/Tests/Source/AssetDownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetDownloadRequestStrategyTests.swift
@@ -70,7 +70,7 @@ class AssetDownloadRequestStrategyTests: MessagingTest {
         sha: Data  = Data.randomEncryptionKey()
         ) -> (message: ZMAssetClientMessage, assetId: String, assetToken: String)? {
 
-        let message = conversation.appendMessage(with: ZMFileMetadata(fileURL: testDataURL)) as! ZMAssetClientMessage
+        let message = conversation.appendMessage(with: ZMFileMetadata(fileURL: testDataURL), version3: true) as! ZMAssetClientMessage
 
         let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
 

--- a/Tests/Source/AssetV3PreviewDownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetV3PreviewDownloadRequestStrategyTests.swift
@@ -1,0 +1,192 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import ZMCDataModel
+import ZMTesting
+@testable import WireMessageStrategy
+
+
+private let testDataURL = Bundle(for: AssetV3PreviewDownloadRequestStrategyTests.self).url(forResource: "Lorem Ipsum", withExtension: "txt")!
+
+
+class AssetV3PreviewDownloadRequestStrategyTests: MessagingTest {
+
+    var authStatus: MockClientRegistrationStatus!
+    var sut: AssetV3PreviewDownloadRequestStrategy!
+    var conversation: ZMConversation!
+
+    typealias PreviewMeta = (otr: Data, sha: Data, assetId: String, token: String)
+
+    override func setUp() {
+        super.setUp()
+        authStatus = MockClientRegistrationStatus()
+        sut = AssetV3PreviewDownloadRequestStrategy(
+            authStatus: authStatus,
+            managedObjectContext: syncMOC
+        )
+        conversation = createConversation()
+    }
+
+    fileprivate func createConversation() -> ZMConversation {
+        let conversation = ZMConversation.insertNewObject(in: syncMOC)
+        conversation.remoteIdentifier = UUID.create()
+        return conversation
+    }
+
+    fileprivate func createMessage(in conversation: ZMConversation) -> (message: ZMAssetClientMessage, assetId: String, assetToken: String)? {
+
+        let message = conversation.appendMessage(with: ZMFileMetadata(fileURL: testDataURL), version3: true) as! ZMAssetClientMessage
+        let (otrKey, sha) = (Data.randomEncryptionKey(), Data.randomEncryptionKey())
+        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+
+        // TODO: We should replace this manual update with inserting a v3 asset as soon as we have sending support
+        let uploaded = ZMGenericMessage.genericMessage(
+            withUploadedOTRKey: otrKey,
+            sha256: sha,
+            messageID: message.nonce.transportString(),
+            expiresAfter: NSNumber(value: conversation.messageDestructionTimeout)
+        )
+
+        guard let uploadedWithId = uploaded.updated(withAssetId: assetId, token: token) else {
+            XCTFail("Failed to update asset")
+            return nil
+        }
+
+        message.add(uploadedWithId)
+        message.fileMessageData?.transferState = .downloading
+
+        prepareDownload(of: message)
+        return (message, assetId, token)
+    }
+
+    func prepareDownload(of message: ZMAssetClientMessage) {
+        syncMOC.saveOrRollback()
+
+        sut.contextChangeTrackers.forEach { tracker in
+            tracker.objectsDidChange(Set(arrayLiteral: message))
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+
+    func createPreview(with nonce: String, otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
+        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let assetBuilder = ZMAsset.builder()
+        let previewBuilder = ZMAssetPreview.builder()
+        let remoteBuilder = ZMAssetRemoteData.builder()
+
+        _ = remoteBuilder?.setOtrKey(otr)
+        _ = remoteBuilder?.setSha256(sha)
+        _ = remoteBuilder?.setAssetId(assetId)
+        _ = remoteBuilder?.setAssetToken(token)
+        _ = previewBuilder?.setSize(512)
+        _ = previewBuilder?.setMimeType("image/jpg")
+        _ = previewBuilder?.setRemote(remoteBuilder)
+        _ = assetBuilder?.setPreview(previewBuilder)
+
+        let previewMeta = (otr, sha, assetId, token)
+        return (ZMGenericMessage.genericMessage(asset: assetBuilder!.build(), messageID: nonce), previewMeta)
+    }
+
+    func testThatItGeneratesNoRequestsIfTheStatusIsEmpty() {
+        XCTAssertNil(sut.nextRequest())
+    }
+
+    func testThatItGeneratesNoRequestsIfNotAuthenticated() {
+        // given
+        authStatus.mockClientIsReadyForRequests = false
+        let _ = createMessage(in: conversation)
+
+        // then
+        XCTAssertNil(sut.nextRequest())
+    }
+
+    func testThatItGeneratesARequestForAV3FileMessageWithPreviewThatHasNotBeenDownloadedYet() {
+        // given
+        let (message, _, _) = createMessage(in: conversation)!
+        let (previewGenericMessage, previewMeta) = createPreview(with: message.nonce.transportString())
+
+        message.add(previewGenericMessage)
+        prepareDownload(of: message)
+
+        guard let asset = message.genericAssetMessage?.assetData else { return XCTFail() }
+        XCTAssertTrue(asset.hasPreview())
+        XCTAssertTrue(asset.preview.hasRemote())
+        XCTAssertTrue(asset.preview.remote.hasAssetId())
+        XCTAssertEqual(asset.preview.remote.assetId, previewMeta.assetId)
+        XCTAssertFalse(message.hasDownloadedImage)
+        XCTAssertEqual(message.version, 3)
+        XCTAssertNotNil(message.fileMessageData)
+
+        // when
+        guard let request = sut.nextRequest() else { return XCTFail("No request generated") }
+
+        // then
+        XCTAssertEqual(request.path, "/assets/v3/\(previewMeta.assetId)")
+        XCTAssertEqual(request.method, .methodGET)
+    }
+
+    func testThatItDoesNotGenerateAReuqestForAV3FileMessageWithPreviewThatAlreadyHasBeenDownloaded() {
+        // given
+        let (message, _, _) = createMessage(in: conversation)!
+        let (previewGenericMessage, previewMeta) = createPreview(with: message.nonce.transportString())
+
+        // when
+        syncMOC.zm_fileAssetCache.storeAssetData(
+            message.nonce,
+            fileName: previewMeta.assetId,
+            encrypted: false,
+            data: Data.secureRandomData(length: 512)
+        )
+
+        message.add(previewGenericMessage)
+        prepareDownload(of: message)
+
+        // then
+        XCTAssertTrue(message.hasDownloadedImage)
+        XCTAssertNil(sut.nextRequest())
+    }
+
+    func testThatItStoresAndDecryptsTheRawDataInTheFileCacheWhenItReceivesAResponse() {
+        // given
+        let plainTextData = Data.secureRandomData(length: 500)
+        let key = Data.randomEncryptionKey()
+        let encryptedData = plainTextData.zmEncryptPrefixingPlainTextIV(key: key)
+        let sha = encryptedData.zmSHA256Digest()
+        let (message, _, _) = createMessage(in: conversation)!
+        let (previewGenericMessage, previewMeta) = createPreview(with: message.nonce.transportString(), otr: key, sha: sha)
+
+        message.add(previewGenericMessage)
+        prepareDownload(of: message)
+
+        // when
+        guard let request = sut.nextRequest() else { return XCTFail("No request generated") }
+        let response = ZMTransportResponse(imageData: encryptedData, httpStatus: 200, transportSessionError: nil, headers: nil)
+
+        request.complete(with: response)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+
+        let data = syncMOC.zm_fileAssetCache.assetData(message.nonce, fileName: previewMeta.assetId, encrypted: false)
+        XCTAssertEqual(data, plainTextData)
+    }
+
+}

--- a/WireMessageStrategy.xcodeproj/project.pbxproj
+++ b/WireMessageStrategy.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF260C501DCA1FD9009C97D9 /* AssetV3PreviewDownloadStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF260C4F1DCA1FD9009C97D9 /* AssetV3PreviewDownloadStrategy.swift */; };
+		BF260C551DCA28C1009C97D9 /* AssetV3PreviewDownloadRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF260C531DCA2435009C97D9 /* AssetV3PreviewDownloadRequestStrategyTests.swift */; };
 		F963E90B1D956FC100098AD3 /* ZMMessageExpirationTimerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F963E9091D956EE700098AD3 /* ZMMessageExpirationTimerTests.m */; };
 		F963E9221D95885700098AD3 /* AssetDownloadRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F963E91F1D95885700098AD3 /* AssetDownloadRequestStrategy.swift */; };
 		F963E9231D95885700098AD3 /* ImageDownloadRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F963E9201D95885700098AD3 /* ImageDownloadRequestStrategy.swift */; };
@@ -113,6 +115,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BF260C4F1DCA1FD9009C97D9 /* AssetV3PreviewDownloadStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetV3PreviewDownloadStrategy.swift; sourceTree = "<group>"; };
+		BF260C531DCA2435009C97D9 /* AssetV3PreviewDownloadRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetV3PreviewDownloadRequestStrategyTests.swift; sourceTree = "<group>"; };
 		F963E9091D956EE700098AD3 /* ZMMessageExpirationTimerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMMessageExpirationTimerTests.m; sourceTree = "<group>"; };
 		F963E91F1D95885700098AD3 /* AssetDownloadRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDownloadRequestStrategy.swift; sourceTree = "<group>"; };
 		F963E9201D95885700098AD3 /* ImageDownloadRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageDownloadRequestStrategy.swift; sourceTree = "<group>"; };
@@ -305,6 +309,7 @@
 				F963E9331D958BBE00098AD3 /* MissingClientsRequestFactory.swift */,
 				F963E9341D958BBE00098AD3 /* MissingClientsRequestStrategy.swift */,
 				F963E91F1D95885700098AD3 /* AssetDownloadRequestStrategy.swift */,
+				BF260C4F1DCA1FD9009C97D9 /* AssetV3PreviewDownloadStrategy.swift */,
 				F963E9201D95885700098AD3 /* ImageDownloadRequestStrategy.swift */,
 				F963E9211D95885700098AD3 /* LinkPreviewAssetDownloadRequestStrategy.swift */,
 				F9F057D01D943D8000FA1AAD /* FileUploadRequestStrategy.swift */,
@@ -434,6 +439,7 @@
 				F9F057EB1D954CD700FA1AAD /* LinkPreviewAssetUploadRequestStrategyTests.swift */,
 				F9F057EC1D954CD700FA1AAD /* LinkPreviewPreprocessorTests.swift */,
 				F963E92A1D95899300098AD3 /* AssetDownloadRequestStrategyTests.swift */,
+				BF260C531DCA2435009C97D9 /* AssetV3PreviewDownloadRequestStrategyTests.swift */,
 				F963E92B1D95899300098AD3 /* ImageDownloadRequestStrategyTests.swift */,
 			);
 			path = Source;
@@ -687,6 +693,7 @@
 				F963E9291D95890E00098AD3 /* AssetDownloadRequestFactory.swift in Sources */,
 				F9F057431D93DDA900FA1AAD /* ZMOTRMessage+Missing.swift in Sources */,
 				F9F057401D93DD5300FA1AAD /* ClientMessageRequestFactory+Files.swift in Sources */,
+				BF260C501DCA1FD9009C97D9 /* AssetV3PreviewDownloadStrategy.swift in Sources */,
 				F963E9241D95885700098AD3 /* LinkPreviewAssetDownloadRequestStrategy.swift in Sources */,
 				F9F056F21D93D3FF00FA1AAD /* ZMMessageExpirationTimer.m in Sources */,
 				F9F057E41D95384200FA1AAD /* LinkPreviewPreprocessor.swift in Sources */,
@@ -706,6 +713,7 @@
 				F9F057F11D954CD700FA1AAD /* LinkPreviewAssetUploadRequestStrategyTests.swift in Sources */,
 				F9F057AC1D941B4B00FA1AAD /* MessagingTest.m in Sources */,
 				F963E92E1D9589C100098AD3 /* ImageDownloadRequestStrategyTests.swift in Sources */,
+				BF260C551DCA28C1009C97D9 /* AssetV3PreviewDownloadRequestStrategyTests.swift in Sources */,
 				F9F0575B1D94129600FA1AAD /* ZMClientMessageTranscoderTests.m in Sources */,
 				F963E90B1D956FC100098AD3 /* ZMMessageExpirationTimerTests.m in Sources */,
 				F963E94A1D9A67FF00098AD3 /* RequestStrategyTestBase.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

This adds a new strategy which is only used to download preview images for files uploaded using the `/assets/v3` endpoint. The reason not to put this logic in the v3 file download strategy is as follows:

* There are multiple things we want for file downloads but not for the image preview, like progress etc.
* The AssetDownloadStrategy already has to deal with v2 and v3 assets, increasing this to preview images makes the code hard to reason about and unnecessarily bloats this class.

Update tests for a new data model with a asset client message version identifier.