### PR TITLE
Add whitelist to AssetV3PreviewDownloadRequestStrategy and fix predicate

### DIFF
--- a/Source/Transcoders/ImageDownloadRequestStrategy.swift
+++ b/Source/Transcoders/ImageDownloadRequestStrategy.swift
@@ -41,7 +41,7 @@ public final class ImageDownloadRequestStrategy : ZMObjectSyncStrategy, RequestS
                                                              entityName: ZMAssetClientMessage.entityName(),
                                                              predicateForObjectsToDownload: downloadPredicate,
                                                              managedObjectContext: managedObjectContext)
-        
+
         registerForWhitelistingNotification()
     }
     


### PR DESCRIPTION
# What's in this PR?

The `AssetV3PreviewDownloadRequestStrategy` used a wrong predicate only downloading the preview when the assets `transferState` was `.downloading`, instead we want to whitelist the image download when the UI calls `requestImageDownload`.
Thus this PR changes the implementation to use a `ZMDownstreamObjectSyncWithWhitelist` and listen to image download notifications as well as  adjusts the predicate for objects that need to be downloaded.