### PR TITLE
Use correct cache key

### DIFF
--- a/Tests/Source/AssetV3DownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetV3DownloadRequestStrategyTests.swift
@@ -73,6 +73,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTest {
 
         message.add(uploadedWithId)
         configureForDownloading(message: message)
+        XCTAssertEqual(message.version, 3)
         return (message, assetId, token)
     }
 
@@ -87,7 +88,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTest {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
 
-    func testThatItGeneratesARequestToTheV3EndpointITheProtobufContainsAnAssetID_V3() {
+    func testThatItGeneratesARequestToTheV3EndpointIfTheProtobufContainsAnAssetID_V3() {
         // Given
         guard let (message, assetId, token) = createFileMessageWithAssetId(in: createConversation()) else { return XCTFail("No message") }
 


### PR DESCRIPTION
# What's in this PR?

* Instead of only using the asset ID as cache key / url we now use the version with the filename appended.