### PR TITLE
Fix bug preprocessing the full asset before in the uploadingFullAsset state

### DIFF
--- a/Source/Helpers/FilePreprocessor.swift
+++ b/Source/Helpers/FilePreprocessor.swift
@@ -41,15 +41,15 @@ It creates an encrypted version from the plain text version
     /// are called from the thread of this managed object context
     let managedObjectContext : NSManagedObjectContext
 
-    private let additionalPredicate: NSPredicate
+    private let filter: NSPredicate
     
     /// Creates a file processor
     /// - note: All methods of this object should be called from the thread associated with the passed managedObjectContext
-    public init(managedObjectContext: NSManagedObjectContext, additionalPredicate: NSPredicate) {
+    public init(managedObjectContext: NSManagedObjectContext, filter: NSPredicate) {
         self.processingGroup = managedObjectContext.dispatchGroup
         self.processingQueue = DispatchQueue(label: "File processor")
         self.managedObjectContext = managedObjectContext
-        self.additionalPredicate = additionalPredicate
+        self.filter = filter
     }
     
     public func objectsDidChange(_ object: Set<NSManagedObject>) {
@@ -60,7 +60,7 @@ It creates an encrypted version from the plain text version
     
     public func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
         let predicate = NSPredicate(format: "%K == NO && %K == %d", DeliveredKey, ZMAssetClientMessageTransferStateKey, ZMFileTransferState.uploading.rawValue)
-        let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, additionalPredicate])
+        let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, filter])
         return ZMAssetClientMessage.sortedFetchRequest(with: compound)
     }
     
@@ -89,7 +89,7 @@ It creates an encrypted version from the plain text version
     /// Returns the object as a ZMAssetClientMessage if it is asset that needs preprocessing
     private func fileAssetToPreprocess(_ obj: NSObject) -> ZMAssetClientMessage? {
         guard let message = obj as? ZMAssetClientMessage else { return nil }
-        return message.needsEncryptedFile && additionalPredicate.evaluate(with: message) ? message : nil
+        return message.needsEncryptedFile && filter.evaluate(with: message) ? message : nil
     }
 }
 

--- a/Source/Helpers/FilePreprocessor.swift
+++ b/Source/Helpers/FilePreprocessor.swift
@@ -41,15 +41,15 @@ It creates an encrypted version from the plain text version
     /// are called from the thread of this managed object context
     let managedObjectContext : NSManagedObjectContext
 
-    private let versionPredicate: NSPredicate
+    private let additionalPredicate: NSPredicate
     
     /// Creates a file processor
     /// - note: All methods of this object should be called from the thread associated with the passed managedObjectContext
-    public init(managedObjectContext: NSManagedObjectContext, versionPredicate: NSPredicate) {
+    public init(managedObjectContext: NSManagedObjectContext, additionalPredicate: NSPredicate) {
         self.processingGroup = managedObjectContext.dispatchGroup
         self.processingQueue = DispatchQueue(label: "File processor")
         self.managedObjectContext = managedObjectContext
-        self.versionPredicate = versionPredicate
+        self.additionalPredicate = additionalPredicate
     }
     
     public func objectsDidChange(_ object: Set<NSManagedObject>) {
@@ -60,7 +60,7 @@ It creates an encrypted version from the plain text version
     
     public func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
         let predicate = NSPredicate(format: "%K == NO && %K == %d", DeliveredKey, ZMAssetClientMessageTransferStateKey, ZMFileTransferState.uploading.rawValue)
-        let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+        let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, additionalPredicate])
         return ZMAssetClientMessage.sortedFetchRequest(with: compound)
     }
     
@@ -89,7 +89,7 @@ It creates an encrypted version from the plain text version
     /// Returns the object as a ZMAssetClientMessage if it is asset that needs preprocessing
     private func fileAssetToPreprocess(_ obj: NSObject) -> ZMAssetClientMessage? {
         guard let message = obj as? ZMAssetClientMessage else { return nil }
-        return message.needsEncryptedFile && versionPredicate.evaluate(with: message) ? message : nil
+        return message.needsEncryptedFile && additionalPredicate.evaluate(with: message) ? message : nil
     }
 }
 

--- a/Source/Transcoders/AssetV3FileUploadRequestStrategy.swift
+++ b/Source/Transcoders/AssetV3FileUploadRequestStrategy.swift
@@ -25,8 +25,8 @@ extension ZMAssetClientMessage {
 
     static var v3_fileUploadPredicate: NSPredicate {
         return NSPredicate(
-            format: "version == 3 && %K != %d && %K == %d",
-            ZMAssetClientMessageUploadedStateKey, ZMAssetUploadState.done.rawValue,
+            format: "version == 3 && %K == %d && %K == %d",
+            ZMAssetClientMessageUploadedStateKey, ZMAssetUploadState.uploadingFullAsset.rawValue,
             ZMAssetClientMessageTransferStateKey, ZMFileTransferState.uploading.rawValue
         )
     }
@@ -67,8 +67,8 @@ public final class AssetV3FileUploadRequestStrategy: ZMObjectSyncStrategy, Reque
     public init(clientRegistrationStatus: ClientRegistrationDelegate, taskCancellationProvider: ZMRequestCancellation, managedObjectContext: NSManagedObjectContext) {
         self.clientRegistrationStatus = clientRegistrationStatus
         self.taskCancellationProvider = taskCancellationProvider
-        let versionPredicate = NSPredicate(format: "version == 3")
-        filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, versionPredicate: versionPredicate)
+        let versionPredicate = NSPredicate(format: "version == 3 && uploadState == %d", ZMAssetUploadState.uploadingFullAsset.rawValue)
+        filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, additionalPredicate: versionPredicate)
         assetAnalytics = AssetAnalytics(managedObjectContext: managedObjectContext)
 
         super.init(managedObjectContext: managedObjectContext)

--- a/Source/Transcoders/AssetV3FileUploadRequestStrategy.swift
+++ b/Source/Transcoders/AssetV3FileUploadRequestStrategy.swift
@@ -67,8 +67,8 @@ public final class AssetV3FileUploadRequestStrategy: ZMObjectSyncStrategy, Reque
     public init(clientRegistrationStatus: ClientRegistrationDelegate, taskCancellationProvider: ZMRequestCancellation, managedObjectContext: NSManagedObjectContext) {
         self.clientRegistrationStatus = clientRegistrationStatus
         self.taskCancellationProvider = taskCancellationProvider
-        let versionPredicate = NSPredicate(format: "version == 3 && uploadState == %d", ZMAssetUploadState.uploadingFullAsset.rawValue)
-        filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, additionalPredicate: versionPredicate)
+        let filter = NSPredicate(format: "version == 3 && uploadState == %d", ZMAssetUploadState.uploadingFullAsset.rawValue)
+        filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, filter: filter)
         assetAnalytics = AssetAnalytics(managedObjectContext: managedObjectContext)
 
         super.init(managedObjectContext: managedObjectContext)

--- a/Source/Transcoders/FileUploadRequestStrategy.swift
+++ b/Source/Transcoders/FileUploadRequestStrategy.swift
@@ -67,7 +67,7 @@ private let reponseHeaderAssetIdKey = "Location"
         )
 
         let versionPredicate = NSPredicate(format: "version < 3")
-        self.filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, versionPredicate: versionPredicate)
+        self.filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, additionalPredicate: versionPredicate)
         self.clientRegistrationStatus = clientRegistrationStatus
         self.requestFactory = ClientMessageRequestFactory()
         self.taskCancellationProvider = taskCancellationProvider

--- a/Source/Transcoders/FileUploadRequestStrategy.swift
+++ b/Source/Transcoders/FileUploadRequestStrategy.swift
@@ -66,8 +66,8 @@ private let reponseHeaderAssetIdKey = "Location"
             entityClass: ZMAssetClientMessage.self
         )
 
-        let versionPredicate = NSPredicate(format: "version < 3")
-        self.filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, additionalPredicate: versionPredicate)
+        let filter = NSPredicate(format: "version < 3")
+        self.filePreprocessor = FilePreprocessor(managedObjectContext: managedObjectContext, filter: filter)
         self.clientRegistrationStatus = clientRegistrationStatus
         self.requestFactory = ClientMessageRequestFactory()
         self.taskCancellationProvider = taskCancellationProvider

--- a/Tests/Source/FilePreprocessorTests.swift
+++ b/Tests/Source/FilePreprocessorTests.swift
@@ -28,7 +28,7 @@ class FilePreprocessorTests : MessagingTest {
 
     override func setUp() {
         super.setUp()
-        sut = FilePreprocessor(managedObjectContext: self.syncMOC, additionalPredicate: NSPredicate(value: true))
+        sut = FilePreprocessor(managedObjectContext: self.syncMOC, filter: NSPredicate(value: true))
     }
 
 }
@@ -45,7 +45,7 @@ extension FilePreprocessorTests {
 
         // given
         let name = "report.txt"
-        sut = FilePreprocessor(managedObjectContext: syncMOC, additionalPredicate: NSPredicate(format: "version > 2"))
+        sut = FilePreprocessor(managedObjectContext: syncMOC, filter: NSPredicate(format: "version > 2"))
         let metadata = ZMFileMetadata(fileURL: testDataURL)
         let msg = ZMAssetClientMessage(fileMetadata: metadata, nonce: UUID.create(), managedObjectContext: syncMOC, expiresAfter:0.0)
 
@@ -69,7 +69,7 @@ extension FilePreprocessorTests {
 
         // given
         let name = "report.txt"
-        sut = FilePreprocessor(managedObjectContext: syncMOC, additionalPredicate: NSPredicate(value: false))
+        sut = FilePreprocessor(managedObjectContext: syncMOC, filter: NSPredicate(value: false))
         let metadata = ZMFileMetadata(fileURL: testDataURL)
         let msg = ZMAssetClientMessage(fileMetadata: metadata, nonce: UUID.create(), managedObjectContext: syncMOC, expiresAfter:0.0)
 

--- a/Tests/Source/FilePreprocessorTests.swift
+++ b/Tests/Source/FilePreprocessorTests.swift
@@ -28,7 +28,7 @@ class FilePreprocessorTests : MessagingTest {
 
     override func setUp() {
         super.setUp()
-        sut = FilePreprocessor(managedObjectContext: self.syncMOC, versionPredicate: NSPredicate(value: true))
+        sut = FilePreprocessor(managedObjectContext: self.syncMOC, additionalPredicate: NSPredicate(value: true))
     }
 
 }
@@ -45,7 +45,7 @@ extension FilePreprocessorTests {
 
         // given
         let name = "report.txt"
-        sut = FilePreprocessor(managedObjectContext: syncMOC, versionPredicate: NSPredicate(format: "version > 2"))
+        sut = FilePreprocessor(managedObjectContext: syncMOC, additionalPredicate: NSPredicate(format: "version > 2"))
         let metadata = ZMFileMetadata(fileURL: testDataURL)
         let msg = ZMAssetClientMessage(fileMetadata: metadata, nonce: UUID.create(), managedObjectContext: syncMOC, expiresAfter:0.0)
 
@@ -69,7 +69,7 @@ extension FilePreprocessorTests {
 
         // given
         let name = "report.txt"
-        sut = FilePreprocessor(managedObjectContext: syncMOC, versionPredicate: NSPredicate(value: false))
+        sut = FilePreprocessor(managedObjectContext: syncMOC, additionalPredicate: NSPredicate(value: false))
         let metadata = ZMFileMetadata(fileURL: testDataURL)
         let msg = ZMAssetClientMessage(fileMetadata: metadata, nonce: UUID.create(), managedObjectContext: syncMOC, expiresAfter:0.0)
 


### PR DESCRIPTION
# What's in this PR?

We were starting the file preprocessing (full asset) as soon as the user inserts a file message (v3), when this operation completes an `Asset.Uploaded` with the otr key and the sha256 of the encrypted file is added to the data set of the message. This operation can happen very fast and lead to the `Asset.Uploaded` being uploaded together with the `Asset.Original`. This is not necessarily a bad thing, but we set the `uploadState` to `.uploaded` on the receiving side as soon as we receive a generic message containing an `Asset.Uploaded`. 

This PR fixes this issue and modifies the predicate for the file preprocessing to start when the `uploadingState` is set to `.uploadingFullAsset`. There is another possibility to check this on the receiving side and only change the state to `.uploaded` when there is an actual assetId (either in the protobuf for v3 assets to in the update event payload itself for v2).