### PR TITLE
forward updated messages to local notification dispatcher

### DIFF
--- a/Source/Transcoders/ZMClientMessageTranscoder.m
+++ b/Source/Transcoders/ZMClientMessageTranscoder.m
@@ -146,8 +146,7 @@
                     }
                 }
             }
-            if (event.source == ZMUpdateEventSourcePushNotification &&
-                (updateResult.wasInserted && updateResult.message != nil))
+            if (event.source == ZMUpdateEventSourcePushNotification && updateResult.message != nil)
             {
                 ZMGenericMessage *genericMessage = [ZMGenericMessage genericMessageFromUpdateEvent:event];
                 if (genericMessage != nil) {


### PR DESCRIPTION
**In this PR**
We are currently not creating notifications for images sent from iOS. The cause is the change from fetching an individual event when receiving an APNS to fetching the notification stream and the fact that we are still sending preview images for image messages.

_The previous behaviour:_ 
We receive a push event for the medium image
fetch the event
insert a message accordingly 
create a notification

_The new behaviour:_
We receive a push event for the medium image
fetch all missed event (which includes the preview image which does not create an APNS but is still sent on iOS)
insert a message for the preview event, 
update the message with the medium event 
Bug: do not create a notification because the causing push did NOT insert, but update a message
Fix: forward updated message and create notification

We don't necessarily need the check if the message was inserted, we can just check the existing notification to avoid duplications (which we already do).