### PR TITLE
Add asset v3 download logging

### DIFF
--- a/Tests/Source/AssetV3DownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetV3DownloadRequestStrategyTests.swift
@@ -223,8 +223,10 @@ extension AssetV3DownloadRequestStrategyTests {
         let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 200, transportSessionError: .none)
 
         // when
-        request?.complete(with: response)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        performIgnoringZMLogError {
+            request?.complete(with: response)
+            XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
 
         // then
         XCTAssertEqual(message.fileMessageData?.transferState.rawValue, ZMFileTransferState.failedDownload.rawValue)
@@ -238,6 +240,7 @@ extension AssetV3DownloadRequestStrategyTests {
 
         // when
         message.transferState = .uploaded
+        
         request?.complete(with: response)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 


### PR DESCRIPTION
# What's in this PR?

[#7660](https://wearezeta.atlassian.net/browse/ZIOS-7660): Very rarely files uploaded using the `/assets/v3` endpoint have been unable to download on the receiving side. When checking the logs it is visible that the file is actually uploaded and downloaded successfully, so there either has to be a condition in which the data can be corrupted, the keys don't match or something else goes wrong when trying to decrypt the data. To find the root of this issue this PR adds more logging to the decryption step after downloading a v3 asset.