### PR TITLE
Add option to choose how many image to process in parallel 

### DIFF
--- a/Source/Transcoders/ImageUploadRequestStrategy.swift
+++ b/Source/Transcoders/ImageUploadRequestStrategy.swift
@@ -25,10 +25,16 @@ public final class ImageUploadRequestStrategy: ZMObjectSyncStrategy, RequestStra
     fileprivate let requestFactory : ClientMessageRequestFactory = ClientMessageRequestFactory()
     fileprivate weak var clientRegistrationStatus : ClientRegistrationDelegate?
     fileprivate var upstreamSync : ZMUpstreamModifiedObjectSync!
+
+    public convenience init(clientRegistrationStatus: ClientRegistrationDelegate,
+                managedObjectContext: NSManagedObjectContext)
+    {
+        self.init(clientRegistrationStatus: clientRegistrationStatus, managedObjectContext: managedObjectContext, maxConcurrentImageOperation: nil)
+    }
     
     public init(clientRegistrationStatus: ClientRegistrationDelegate,
                 managedObjectContext: NSManagedObjectContext,
-                maxConcurrentImageOperation: Int? = nil)
+                maxConcurrentImageOperation: Int?)
     {
         self.clientRegistrationStatus = clientRegistrationStatus
         let fetchPredicate = NSPredicate(format: "delivered == NO && version < 3")

--- a/Source/Transcoders/ImageUploadRequestStrategy.swift
+++ b/Source/Transcoders/ImageUploadRequestStrategy.swift
@@ -27,13 +27,18 @@ public final class ImageUploadRequestStrategy: ZMObjectSyncStrategy, RequestStra
     fileprivate var upstreamSync : ZMUpstreamModifiedObjectSync!
     
     public init(clientRegistrationStatus: ClientRegistrationDelegate,
-                managedObjectContext: NSManagedObjectContext)
+                managedObjectContext: NSManagedObjectContext,
+                maxConcurrentImageOperation: Int? = nil)
     {
         self.clientRegistrationStatus = clientRegistrationStatus
         let fetchPredicate = NSPredicate(format: "delivered == NO && version < 3")
         let needsProcessingPredicate = NSPredicate(format: "(mediumGenericMessage.imageAssetData.width == 0 || previewGenericMessage.imageAssetData.width == 0) && delivered == NO")
+        let imageOperationQueue = OperationQueue()
+        if let maxConcurrentImageOperation = maxConcurrentImageOperation {
+            imageOperationQueue.maxConcurrentOperationCount = maxConcurrentImageOperation
+        }
         self.imagePreprocessor = ZMImagePreprocessingTracker(managedObjectContext: managedObjectContext,
-                                                             imageProcessingQueue: OperationQueue(),
+                                                             imageProcessingQueue: imageOperationQueue,
                                                              fetch: fetchPredicate,
                                                              needsProcessingPredicate: needsProcessingPredicate,
                                                              entityClass: ZMAssetClientMessage.self)


### PR DESCRIPTION
**What's in this PR**
This PR adds an option to configure the amount of concurrent image processing operation.
This is needed for share extension (which sets it to a serial queue), as this would allocate too much memory, and the system would kill the extension.