### PR TITLE
Conform MissingClientsRequestStrategy to RequestStrategy protocol

### DIFF
--- a/Source/Helpers/ZMOTRMessage+Missing.swift
+++ b/Source/Helpers/ZMOTRMessage+Missing.swift
@@ -82,7 +82,7 @@ public extension ZMOTRMessage {
         let allMissingClients = Set(missingMap.flatMap { pair -> [UserClient] in
             
             // user
-            guard let userID = UUID(uuidString: pair.0) else { return []}
+            guard let userID = UUID(uuidString: pair.0) else { return [] }
             let user = ZMUser(remoteID: userID, createIfNeeded: true, in: self.managedObjectContext!)!
             
             // client

--- a/Source/Transcoders/MissingClientsRequestStrategy.swift
+++ b/Source/Transcoders/MissingClientsRequestStrategy.swift
@@ -79,7 +79,7 @@ public final class MissingClientsRequestStrategy: ZMObjectSyncStrategy, ZMObject
     }
     
     public func nextRequest() -> ZMTransportRequest? {
-        guard let clientStatus = clientRegistrationStatus , clientStatus.clientIsReadyForRequests
+        guard let clientStatus = clientRegistrationStatus, clientStatus.clientIsReadyForRequests
         else { return nil }
         
         return modifiedSync.nextRequest()
@@ -92,6 +92,7 @@ public final class MissingClientsRequestStrategy: ZMObjectSyncStrategy, ZMObject
     public var hasOutstandingItems : Bool {
         return modifiedSync.hasOutstandingItems
     }
+
     public func shouldProcessUpdatesBeforeInserts() -> Bool {
         return false
     }
@@ -116,11 +117,11 @@ public final class MissingClientsRequestStrategy: ZMObjectSyncStrategy, ZMObject
         guard keys.contains(ZMUserClientMissingKey)
         else { fatal("Unknown keys to sync (\(keys))") }
         
-        guard let missing = client.missingClients , missing.count > 0
+        guard let missing = client.missingClients, missing.count > 0
         else { fatal("no missing clients found") }
         
         let request = requestsFactory.fetchMissingClientKeysRequest(missing)
-        if let confStatus = apnsConfirmationStatus , confStatus.needsToSyncMessages {
+        if let confStatus = apnsConfirmationStatus, confStatus.needsToSyncMessages {
             request?.transportRequest.forceToVoipSession()
         }
         return request

--- a/Source/Transcoders/MissingClientsRequestStrategy.swift
+++ b/Source/Transcoders/MissingClientsRequestStrategy.swift
@@ -48,7 +48,7 @@ public extension UserClient {
 
 // Register new client, update it with new keys, deletes clients.
 @objc
-public final class MissingClientsRequestStrategy: ZMObjectSyncStrategy, ZMObjectStrategy, ZMUpstreamTranscoder {
+public final class MissingClientsRequestStrategy: ZMObjectSyncStrategy, ZMObjectStrategy, ZMUpstreamTranscoder, RequestStrategy {
     
     weak var clientRegistrationStatus: ClientRegistrationDelegate?
     weak var apnsConfirmationStatus: DeliveryConfirmationDelegate?


### PR DESCRIPTION
# What's in this PR?

* The share extension did not fetch missing clients when receiving a 412 when sending a message, this was due to the `MissingClientsRequestStrategy` not correctly being included in the set of potential request generators.
* The `MissingClientsRequestStrategy` implements the `nextRequest` method and is thus conforming to the `RequestStrategy` protocol, but was not declared as doing so.
* The conformance is needed in `wire-ios-share-engine` when we construct the set of request generators, where we check for conformance to `RequestStrategy` or `ZMRequestGeneratorSource`.