### PR TITLE
Set application extension only API flag to YES

### DIFF
--- a/WireMessageStrategy.xcodeproj/project.pbxproj
+++ b/WireMessageStrategy.xcodeproj/project.pbxproj
@@ -944,6 +944,7 @@
 		F9F056C81D93D22000FA1AAD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = W5KEQBF9B5;
@@ -975,6 +976,7 @@
 		F9F056C91D93D22000FA1AAD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = W5KEQBF9B5;


### PR DESCRIPTION
# What's in this PR?

* Set `APPLICATION_EXTENSION_API_ONLY ` in order to remove warnings in other frameworks.