### PR TITLE
Fix image message uploaded state not being set to `.done` after successful upload

### DIFF
--- a/Source/Transcoders/AssetClientMessageRequestStrategy.swift
+++ b/Source/Transcoders/AssetClientMessageRequestStrategy.swift
@@ -101,6 +101,7 @@ extension AssetClientMessageRequestStrategy: ZMUpstreamTranscoder {
         if response.result == .success {
             if message.fileMessageData?.v3_isImage() == true {
                 message.delivered = true
+                message.uploadState = .done
                 message.markAsSent()
             } else {
                 return updateNonImageFileMessageStatus(for: message, response: response)

--- a/Tests/Source/AssetClientMessageRequestStrategyTests.swift
+++ b/Tests/Source/AssetClientMessageRequestStrategyTests.swift
@@ -366,6 +366,7 @@ class AssetClientMessageRequestStrategyTests: MessagingTest {
         // then
         XCTAssert(message.delivered)
         XCTAssertEqual(message.deliveryState, .sent)
+        XCTAssertEqual(message.uploadState, .done)
         XCTAssertNil(sut.nextRequest())
     }
 


### PR DESCRIPTION
# What's in this PR?

* We failed to set the `uploadState` after successful uploading a v3 file message representing an image.