### PR TITLE
Fix failing tests

### DIFF
--- a/Source/Transcoders/ClientMessageTranscoder.swift
+++ b/Source/Transcoders/ClientMessageTranscoder.swift
@@ -150,8 +150,11 @@ extension ClientMessageTranscoder {
     }
     
     fileprivate func deleteOldEphemeralMessages() {
-        ZMMessage.deleteOldEphemeralMessages(self.managedObjectContext)
-        self.managedObjectContext.saveOrRollback()
+        self.managedObjectContext.performGroupedBlock { [weak self] in
+            guard let `self` = self else { return }
+            ZMMessage.deleteOldEphemeralMessages(self.managedObjectContext)
+            self.managedObjectContext.saveOrRollback()
+        }
     }
 
     public func updateInsertedObject(_ managedObject: ZMManagedObject, request upstreamRequest: ZMUpstreamRequest, response: ZMTransportResponse) {

--- a/Tests/Source/ClientMessageTranscoderTests+Ephemeral.swift
+++ b/Tests/Source/ClientMessageTranscoderTests+Ephemeral.swift
@@ -105,6 +105,7 @@ extension ClientMessageTranscoderTests {
         self.spinMainQueue(withTimeout: 8)
         self.syncMOC.refreshAllObjects()
         self.recreateSut()
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         self.syncMOC.saveOrRollback()
         
         // THEN
@@ -137,9 +138,12 @@ extension ClientMessageTranscoderTests {
         self.stopEphemeralMessageTimers()
         
         // WHEN
-        self.syncMOC.refreshAllObjects()
-        self.recreateSut()
-        self.syncMOC.saveOrRollback()
+        self.syncMOC.performGroupedBlockAndWait {
+            self.syncMOC.refreshAllObjects()
+            self.recreateSut()
+            self.syncMOC.saveOrRollback()
+        }
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // THEN
         self.uiMOC.refreshAllObjects()

--- a/Tests/Source/Helpers/MessagingTestBase.swift
+++ b/Tests/Source/Helpers/MessagingTestBase.swift
@@ -41,22 +41,23 @@ class MessagingTestBase: ZMTBaseTest {
         
         self.syncMOC.zm_cryptKeyStore.deleteAndCreateNewBox()
         
-        self.setupUsersAndClients()
-        self.groupConversation = self.createGroupConversation(with: self.otherUser)
-        self.oneToOneConversation = self.setupOneToOneConversation(with: self.otherUser)
-        
-        self.syncMOC.saveOrRollback()
+        self.syncMOC.performGroupedBlockAndWait {
+            self.setupUsersAndClients()
+            self.groupConversation = self.createGroupConversation(with: self.otherUser)
+            self.oneToOneConversation = self.setupOneToOneConversation(with: self.otherUser)
+            self.syncMOC.saveOrRollback()
+        }
     }
     
     override func tearDown() {
 
         _ = self.waitForAllGroupsToBeEmpty(withTimeout: 10)
-        
-        self.otherUser = nil
-        self.otherClient = nil
-        self.selfClient = nil
-        self.groupConversation = nil
-
+        self.syncMOC.performGroupedBlockAndWait {
+            self.otherUser = nil
+            self.otherClient = nil
+            self.selfClient = nil
+            self.groupConversation = nil
+        }
         self.stopEphemeralMessageTimers()
         self.tearDownManagedObjectContexes()
         self.deleteAllFilesInCache()
@@ -275,12 +276,12 @@ extension MessagingTestBase {
         self.syncMOC.performGroupedBlockAndWait {
             self.syncMOC.zm_teardownMessageObfuscationTimer()
         }
-        _ = self.waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         self.uiMOC.performGroupedBlockAndWait {
             self.uiMOC.zm_teardownMessageDeletionTimer()
         }
-        _ = self.waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
 }
 

--- a/Tests/Source/MissingClientsMapTests.swift
+++ b/Tests/Source/MissingClientsMapTests.swift
@@ -26,65 +26,72 @@ import ZMCDataModel
 class MissingClientsMapTests: MessagingTestBase {
     
     func testThatItCreatesMissingMapForClients() {
-        
-        // given
-        let user1Client1 = createClient()
-        let user1Client2 = createClient(user1Client1.user)
-        let user2Client1 = createClient()
-        
-        // when
-        let sut = MissingClientsMap([user1Client1, user1Client2, user2Client1], pageSize: 2)
-        
-        // then
-        guard let user1Id = user1Client1.user?.remoteIdentifier?.transportString(),
-            let user2Id = user2Client1.user?.remoteIdentifier?.transportString() else { return XCTFail() }
-        
-        XCTAssertEqual(sut.payload.keys.count, 2)
-        XCTAssertEqual(sut.payload[user1Id]?.count, 2)
-        XCTAssertEqual(sut.payload[user2Id]?.count, 1)
-        
-        assertPayloadContainsClient(sut, user1Client1)
-        assertPayloadContainsClient(sut, user1Client2)
-        assertPayloadContainsClient(sut, user2Client1)
-        assertExpectedUserInfo(sut, user1Client1, user1Client2, user2Client1)
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            // given
+            let user1Client1 = self.createClient()
+            let user1Client2 = self.createClient(user1Client1.user)
+            let user2Client1 = self.createClient()
+            
+            // when
+            let sut = MissingClientsMap([user1Client1, user1Client2, user2Client1], pageSize: 2)
+            
+            // then
+            guard let user1Id = user1Client1.user?.remoteIdentifier?.transportString(),
+                let user2Id = user2Client1.user?.remoteIdentifier?.transportString() else { return XCTFail() }
+            
+            XCTAssertEqual(sut.payload.keys.count, 2)
+            XCTAssertEqual(sut.payload[user1Id]?.count, 2)
+            XCTAssertEqual(sut.payload[user2Id]?.count, 1)
+            
+            self.assertPayloadContainsClient(sut, user1Client1)
+            self.assertPayloadContainsClient(sut, user1Client2)
+            self.assertPayloadContainsClient(sut, user2Client1)
+            self.assertExpectedUserInfo(sut, user1Client1, user1Client2, user2Client1)
+        }
     }
 
     func testThatItPaginatesMissedClientsMapBasedOnUserCountPageSize() {
-        
-        // given
-        let user1Client1 = createClient()
-        let user1Client2 = createClient(user1Client1.user)
-        
-        // when
-        let sut = MissingClientsMap([user1Client1, user1Client2], pageSize: 1)
-        
-        // then
-        XCTAssertEqual(sut.payload.keys.count, 1)
-        assertPayloadContainsClient(sut, user1Client1)
-        assertPayloadContainsClient(sut, user1Client2)
-        assertExpectedUserInfo(sut, user1Client1, user1Client2)
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            // given
+            let user1Client1 = self.createClient()
+            let user1Client2 = self.createClient(user1Client1.user)
+            
+            // when
+            let sut = MissingClientsMap([user1Client1, user1Client2], pageSize: 1)
+            
+            // then
+            XCTAssertEqual(sut.payload.keys.count, 1)
+            self.assertPayloadContainsClient(sut, user1Client1)
+            self.assertPayloadContainsClient(sut, user1Client2)
+            self.assertExpectedUserInfo(sut, user1Client1, user1Client2)
+        }
     }
     
     func testThatItPaginatesMissedClientsMapBasedOnUserCount_toManyUsers() {
         
-        // given
-        let user1Client1 = createClient()
-        let user2Client1 = createClient()
-        let user2Client2 = createClient(user2Client1.user)
-        let user3Client1 = createClient()
-        
-        // when
-        let sut = MissingClientsMap([user1Client1, user2Client1, user2Client2, user3Client1], pageSize: 2)
-        
-        // then
-        XCTAssertEqual(sut.payload.keys.count, 2)
-        assertPayloadContainsClient(sut, user1Client1)
-        assertPayloadContainsClient(sut, user2Client1)
-        assertPayloadContainsClient(sut, user2Client2)
-
-        guard let user3Id = user3Client1.user?.remoteIdentifier?.transportString() else { return XCTFail() }
-        XCTAssertNil(sut.payload[user3Id])
-        assertExpectedUserInfo(sut, user1Client1, user2Client1, user2Client2)
+        syncMOC.performGroupedBlockAndWait {
+            
+            // given
+            let user1Client1 = self.createClient()
+            let user2Client1 = self.createClient()
+            let user2Client2 = self.createClient(user2Client1.user)
+            let user3Client1 = self.createClient()
+            
+            // when
+            let sut = MissingClientsMap([user1Client1, user2Client1, user2Client2, user3Client1], pageSize: 2)
+            
+            // then
+            XCTAssertEqual(sut.payload.keys.count, 2)
+            self.assertPayloadContainsClient(sut, user1Client1)
+            self.assertPayloadContainsClient(sut, user2Client1)
+            self.assertPayloadContainsClient(sut, user2Client2)
+            
+            guard let user3Id = user3Client1.user?.remoteIdentifier?.transportString() else { return XCTFail() }
+            XCTAssertNil(sut.payload[user3Id])
+            self.assertExpectedUserInfo(sut, user1Client1, user2Client1, user2Client2)
+        }
     }
     
     // MARK: - Helper


### PR DESCRIPTION
If your tests are crashing during a save with the error: "Failed to save: Error Domain=NSCocoaErrorDomain Code=133010" - it's probably because your tests are manipulating sync objects on the main thread. All you need to do is wrap your tests in a syncMoc.performGroupedBlock{} and you are fine. Voilá