### PR TITLE
Mark `ClientMessageTranscoder` as `RequestStrategy`

### DIFF
--- a/Source/Transcoders/ClientMessageTranscoder.swift
+++ b/Source/Transcoders/ClientMessageTranscoder.swift
@@ -64,7 +64,7 @@ extension ClientMessageTranscoder: ZMContextChangeTrackerSource {
     }
 }
 
-extension ClientMessageTranscoder: ZMRequestGenerator {
+extension ClientMessageTranscoder: RequestStrategy {
 
     public func nextRequest() -> ZMTransportRequest? {
         guard let clientRegistrationStatus = self.clientRegistrationStatus,


### PR DESCRIPTION
# What's in this PR?

* `ClientMessageTranscoder` is a strategy now but was not marked as conforming to the `RequestStrategy` protocol.
* This was breaking text message sending from the share extension as `wire-ios-share-engine` doesn't ask `ZMRequestGenerator`s for their `nextRequest` but instead `ZMRequestGeneratorSource`s (which `ClientMessageTranscoder` isn't anymore).