### PR TITLE
Fix multiple preprocessing runs resulting in race condition

### DIFF
--- a/Source/Helpers/FilePreprocessor.swift
+++ b/Source/Helpers/FilePreprocessor.swift
@@ -53,9 +53,7 @@ It creates an encrypted version from the plain text version
     }
     
     public func objectsDidChange(_ object: Set<NSManagedObject>) {
-        object.flatMap(fileAssetToPreprocess)
-            .filter { !self.objectsBeingProcessed.contains($0) }
-            .forEach { self.startProcessing($0) }
+        processObjects(object)
     }
     
     public func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
@@ -64,9 +62,13 @@ It creates an encrypted version from the plain text version
     }
     
     public func addTrackedObjects(_ objects: Set<NSManagedObject>) {
+        processObjects(objects)
+    }
+
+    private func processObjects(_ objects: Set<NSManagedObject>) {
         objects.flatMap(fileAssetToPreprocess)
-            .filter {!self.objectsBeingProcessed.contains($0)}
-            .forEach { self.startProcessing($0)}
+               .filter { !self.objectsBeingProcessed.contains($0) }
+               .forEach { self.startProcessing($0) }
     }
     
     /// Starts processing the asset client message

--- a/Source/Helpers/FilePreprocessor.swift
+++ b/Source/Helpers/FilePreprocessor.swift
@@ -54,14 +54,13 @@ It creates an encrypted version from the plain text version
     
     public func objectsDidChange(_ object: Set<NSManagedObject>) {
         object.flatMap(fileAssetToPreprocess)
-            .filter {!self.objectsBeingProcessed.contains($0)}
+            .filter { !self.objectsBeingProcessed.contains($0) }
             .forEach { self.startProcessing($0) }
     }
     
     public func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
         let predicate = NSPredicate(format: "%K == NO && %K == %d", DeliveredKey, ZMAssetClientMessageTransferStateKey, ZMFileTransferState.uploading.rawValue)
-        let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, filter])
-        return ZMAssetClientMessage.sortedFetchRequest(with: compound)
+        return ZMAssetClientMessage.sortedFetchRequest(with: predicate)
     }
     
     public func addTrackedObjects(_ objects: Set<NSManagedObject>) {
@@ -108,13 +107,20 @@ extension ZMAssetClientMessage {
             && self.imageMessageData == nil
             && !self.delivered
             && self.genericAssetMessage?.assetData?.original.hasImage() == false
+            && self.genericAssetMessage?.assetData?.uploaded.hasOtrKey() == false
             && self.managedObjectContext != nil
             && self.managedObjectContext!.zm_fileAssetCache.assetData(self.nonce, fileName: self.filename!, encrypted: true) == nil
     }
     
     /// Adds Uploaded generic message
     fileprivate func addUploadedGenericMessage(_ keys: ZMImageAssetEncryptionKeys) {
-        let msg = ZMGenericMessage.genericMessage(withUploadedOTRKey: keys.otrKey, sha256: keys.sha256!, messageID: self.nonce.transportString(), expiresAfter: NSNumber(value: self.deletionTimeout))
+        let msg = ZMGenericMessage.genericMessage(
+            withUploadedOTRKey: keys.otrKey,
+            sha256: keys.sha256!,
+            messageID: self.nonce.transportString(),
+            expiresAfter: NSNumber(value: self.deletionTimeout)
+        )
+
         self.add(msg)
     }
 }


### PR DESCRIPTION
# What's in this PR?

**TL;DR: This PR fixes an issue resulting in files being sent that are unable to decrypt / have an sha256 which doesn't match.**

* In very rare cases it happened that file messages (sent using the `/assets/v3` endpoint) could not be decrypted on the receiving side, this only happened for file messages and not images (which are also files and sent using the same endpoint, but by a different `RequestStrategy`). The odd thing to note here is was 100% reproducibly which specific files on specific devices, the `sha256` did not match the file data. The underlying bug was, that the `FilePreprocessor`, which encrypts the file, updates the generic message with the `otrKey` and `sha256` had a wrong predicate. The predicate did not check if there already were encryption keys in the generic message and would thus preprocess the file again.
This means that in specific cases the file gets preprocessed and the encrypted binary data gets uploaded to `/assets/v3/` while in the meantime the file preprocessor might encrypt the file again and update the generic message data with the new keys, which won't match the uploaded data. The message sent to the receiving clients thus could contain encryption keys which would not match the data they would download from `/assets/v3`.
* This also adds some other improvements, for example the `filter` passed to the `FilePreprocessor` was added to the initial fetch request. As our filters usually check properties not in the database (e.g. if an image is in the cache) this can be quite slow. The filter is already checked in `addTrackedObjects` (respectively `fileAssetToPreprocess `).
* There also was a redundant check for the `transferState` in `AssetV3FileUploadRequestStrategy` which didn't make sense.