### PR TITLE
Remove block observers in tests

### DIFF
--- a/Tests/Source/AssetDownloadRequestStrategyTests.swift
+++ b/Tests/Source/AssetDownloadRequestStrategyTests.swift
@@ -370,7 +370,7 @@ extension AssetDownloadRequestStrategyTests {
         
         let notificationExpectation = self.expectation(description: "Notification fired")
         
-        let _ = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: AssetDownloadRequestStrategyNotification.downloadFinishedNotificationName), object: nil, queue: .main) { notification in
+        let token = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: AssetDownloadRequestStrategyNotification.downloadFinishedNotificationName), object: nil, queue: .main) { notification in
             XCTAssertNotNil(notification.userInfo![AssetDownloadRequestStrategyNotification.downloadStartTimestampKey])
             notificationExpectation.fulfill()
         }
@@ -382,19 +382,17 @@ extension AssetDownloadRequestStrategyTests {
             let response = ZMTransportResponse(imageData: encryptedData, httpStatus: 200, transportSessionError: .none, headers: [:])
             request.complete(with: response)
         }
-        
-        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // THEN
-        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        NotificationCenter.default.removeObserver(token)
     }
     
     func testThatItSendsTheNotificationIfCannotDownload() {
         // GIVEN
-        
         let notificationExpectation = self.expectation(description: "Notification fired")
         
-        let _ = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: AssetDownloadRequestStrategyNotification.downloadFailedNotificationName), object: nil, queue: .main) { notification in
+        let token = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: AssetDownloadRequestStrategyNotification.downloadFailedNotificationName), object: nil, queue: .main) { notification in
             XCTAssertNotNil(notification.userInfo![AssetDownloadRequestStrategyNotification.downloadStartTimestampKey])
             notificationExpectation.fulfill()
         }
@@ -410,10 +408,10 @@ extension AssetDownloadRequestStrategyTests {
             let response = ZMTransportResponse(payload: [] as ZMTransportData, httpStatus: 404, transportSessionError: .none)
             request.complete(with: response)
         }
-        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // THEN
-        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        NotificationCenter.default.removeObserver(token)
     }
 }
 

--- a/Tests/Source/FileUploadRequestStrategyTests.swift
+++ b/Tests/Source/FileUploadRequestStrategyTests.swift
@@ -559,7 +559,7 @@ extension FileUploadRequestStrategyTests {
         request.markStartOfUploadTimestamp()
         let notificationExpectation = self.expectation(description: "Notification fired")
         
-        let _ = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: FileUploadRequestStrategyNotification.uploadFinishedNotificationName), object: nil, queue: .main) { notification in
+        let token = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: FileUploadRequestStrategyNotification.uploadFinishedNotificationName), object: nil, queue: .main) { notification in
             XCTAssertNotNil(notification.userInfo![FileUploadRequestStrategyNotification.requestStartTimestampKey])
             notificationExpectation.fulfill()
         }
@@ -571,6 +571,7 @@ extension FileUploadRequestStrategyTests {
         
         // THEN
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+        NotificationCenter.default.removeObserver(token)
     }
     
     func testThatItSendsNotificaitonForAFailedFile() {
@@ -582,7 +583,7 @@ extension FileUploadRequestStrategyTests {
         request.markStartOfUploadTimestamp()
         let notificationExpectation = self.expectation(description: "Notification fired")
         
-        let _ = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: FileUploadRequestStrategyNotification.uploadFailedNotificationName), object: nil, queue: .main) { notification in
+        let token = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: FileUploadRequestStrategyNotification.uploadFailedNotificationName), object: nil, queue: .main) { notification in
             XCTAssertNotNil(notification.userInfo![FileUploadRequestStrategyNotification.requestStartTimestampKey])
             notificationExpectation.fulfill()
         }
@@ -592,6 +593,7 @@ extension FileUploadRequestStrategyTests {
         
         // THEN
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+        NotificationCenter.default.removeObserver(token)
     }
     
     func testThatItDoesNotCancelCurrentlyRunningRequestWhenTheUploadFails_FullAsset() {


### PR DESCRIPTION
# What's in this PR?

* Remove observers created using the `NotificationCenter` blocks API.