### PR TITLE
Refetch all team members after processing a team.member-join event

### DIFF
--- a/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
+++ b/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
@@ -106,7 +106,10 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
         guard let user = ZMUser(remoteID: removedUserId, createIfNeeded: false, in: managedObjectContext) else { return }
         if let member = user.membership(in: team) {
             managedObjectContext.delete(member)
-            // TODO: Delete the team in case the member.user was the self user
+            if user.isSelfUser {
+                // We delete the local team in case the members user was the self user
+                managedObjectContext.delete(team)
+            }
         } else {
             log.error("Trying to delete non existent membership of \(user) in \(team)")
         }

--- a/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
+++ b/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
@@ -90,11 +90,12 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
         // In case we just created this team locally, we want to ensure that we refetch all of its
         // metadata, as well as all member permissions.
         team.needsToBeUpdatedFromBackend = created
+        // cf. https://github.com/wireapp/architecture/issues/13
+        // We want to refetch the members in case we didn't just create the team as the payload does not include permissions.
+        team.needsToRedownloadMembers = !created
         guard let addedUserId = (data[TeamEventPayloadKey.user.rawValue] as? String).flatMap(UUID.init) else { return }
         guard let user = ZMUser(remoteID: addedUserId, createIfNeeded: true, in: managedObjectContext) else { return }
         user.needsToBeUpdatedFromBackend = true
-        // TODO: The event payload does not contain permissions (so far),
-        // should we always refetch the team to ensure we refetch the members with their permissions?
         _ = Member.getOrCreateMember(for: user, in: team, context: managedObjectContext)
     }
 

--- a/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
@@ -360,11 +360,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTestBase {
         // then
         syncMOC.performGroupedBlockAndWait {
             XCTAssertNotNil(ZMUser.fetch(withRemoteIdentifier: userId, in: self.syncMOC))
-
-            // users won't be deleted as we might be in other (non-team) conversations with them
-            guard let team = Team.fetch(withRemoteIdentifier: teamId, in: self.syncMOC) else { return XCTFail("No team") }
-            XCTAssertEqual(team.members, [])
-            XCTAssertNil(ZMUser.selfUser(in: self.syncMOC).membership(in: team))
+            XCTAssertNil(Team.fetch(withRemoteIdentifier: teamId, in: self.syncMOC))
         }
     }
 

--- a/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
@@ -225,6 +225,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTestBase {
 
         XCTAssertTrue(user.needsToBeUpdatedFromBackend)
         XCTAssertFalse(team.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(team.needsToRedownloadMembers)
         XCTAssertEqual(member.team, team)
     }
 
@@ -258,7 +259,8 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTestBase {
             guard let member = user.membership(in: team) else { return XCTFail("No member") }
 
             XCTAssertTrue(user.needsToBeUpdatedFromBackend)
-            XCTAssertFalse(team.needsToBeUpdatedFromBackend) // TODO: Double check if we want to update it
+            XCTAssertFalse(team.needsToBeUpdatedFromBackend)
+            XCTAssertTrue(team.needsToRedownloadMembers)
             XCTAssertEqual(member.team, team)
         }
     }
@@ -286,6 +288,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTestBase {
 
             XCTAssertTrue(user.needsToBeUpdatedFromBackend)
             XCTAssertTrue(team.needsToBeUpdatedFromBackend)
+            XCTAssertFalse(team.needsToRedownloadMembers)
             XCTAssertEqual(member.team, team)
         }
     }


### PR DESCRIPTION
# What's in this PR?

* The `team.member-join` event payload does not include the permissions of the added member.
To be sure we no mark the members as needing to be refetched to ensure we always have all member permissions locally (see https://github.com/wireapp/architecture/issues/13).
* We now delete a local team in case we receive a `team.member-leave` update event for the self user.