### PR TITLE
Remove user from team conversations member leave

### DIFF
--- a/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
+++ b/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
@@ -113,7 +113,12 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
                 deleteTeamAndConversations(team)
             } else {
                 // Remove member from all team conversations he was a participant of
-                team.conversations.filter { $0.otherActiveParticipants.contains(user) }.forEach { $0.removeParticipant(user) }
+                team.conversations.filter {
+                    $0.otherActiveParticipants.contains(user)
+                }.forEach {
+                    $0.removeParticipant(user)
+                    $0.synchronizeRemovedUser(user)
+                }
             }
         } else {
             log.error("Trying to delete non existent membership of \(user) in \(team)")

--- a/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
+++ b/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
@@ -111,6 +111,9 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
             if user.isSelfUser {
                 // We delete the local team in case the members user was the self user
                 deleteTeamAndConversations(team)
+            } else {
+                // Remove member from all team conversations he was a participant of
+                team.conversations.filter { $0.otherActiveParticipants.contains(user) }.forEach { $0.removeParticipant(user) }
             }
         } else {
             log.error("Trying to delete non existent membership of \(user) in \(team)")

--- a/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
@@ -436,6 +436,53 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTestBase {
         }
     }
 
+    func testThatItRemovesAMemberFromAllTeamConversationsSheWasPartOfWhenReceivingAMemberLeaveForThatMember() {
+        let teamId = UUID.create()
+        let teamConversationId = UUID.create(), conversationId = UUID.create()
+        let userId = UUID.create()
+
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            let user = ZMUser.insertNewObject(in: self.syncMOC)
+            user.remoteIdentifier = userId
+            let otherUser = ZMUser.insertNewObject(in: self.syncMOC)
+            otherUser.remoteIdentifier = .create()
+            let team = Team.insertNewObject(in: self.syncMOC)
+            team.remoteIdentifier = teamId
+            let teamConversation1 = ZMConversation.insertNewObject(in: self.syncMOC)
+            teamConversation1.remoteIdentifier = teamConversationId
+            teamConversation1.conversationType = .group
+            teamConversation1.addParticipant(user)
+            teamConversation1.team = team
+            let conversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [user, otherUser])
+            conversation?.remoteIdentifier = conversationId
+            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            XCTAssertNotNil(member)
+            XCTAssertEqual(user.membership(in: team), member)
+        }
+
+        // when
+        let payload: [String: Any] = [
+            "type": "team.member-leave",
+            "team": teamId.transportString(),
+            "time": Date().transportString(),
+            "data": ["user" : userId.transportString()]
+        ]
+        processEvent(fromPayload: payload)
+
+        // then
+        syncMOC.performGroupedBlockAndWait {
+            guard let user = ZMUser.fetch(withRemoteIdentifier: userId, in: self.syncMOC) else { return XCTFail("No User") }
+            guard let team = Team.fetch(withRemoteIdentifier: teamId, in: self.syncMOC) else { return XCTFail("No User") }
+            XCTAssertNil(user.membership(in: team))
+            guard let teamConversation = ZMConversation.fetch(withRemoteIdentifier: teamConversationId, in: self.syncMOC) else { return XCTFail("No Team Conversation") }
+            guard let conversation = ZMConversation.fetch(withRemoteIdentifier: conversationId, in: self.syncMOC) else { return XCTFail("No Conversation") }
+            XCTAssertFalse(teamConversation.otherActiveParticipants.contains(user))
+            print(conversation.otherActiveParticipants)
+            XCTAssert(conversation.otherActiveParticipants.contains(user))
+        }
+    }
+
     // MARK: - Team Conversation-Create
 
     func testThatItCreatesANewTeamConversationWhenReceivingATeamConversationCreateUpdateEvent() {

--- a/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/Tests/Source/TeamDownloadRequestStrategy+EventsTests.swift
@@ -478,7 +478,6 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTestBase {
             guard let teamConversation = ZMConversation.fetch(withRemoteIdentifier: teamConversationId, in: self.syncMOC) else { return XCTFail("No Team Conversation") }
             guard let conversation = ZMConversation.fetch(withRemoteIdentifier: conversationId, in: self.syncMOC) else { return XCTFail("No Conversation") }
             XCTAssertFalse(teamConversation.otherActiveParticipants.contains(user))
-            print(conversation.otherActiveParticipants)
             XCTAssert(conversation.otherActiveParticipants.contains(user))
         }
     }


### PR DESCRIPTION
# What's in this PR?

* When receiving a `team/member-leave` update event for an user other than self, we will not receive any `conversation.member-leave` events. We now remove the removed member from all team conversations manually.
* Fixes https://github.com/wearezeta/backend-issues/issues/573 client-side.
* Currently there is one culprit, which is that there will be no `XYZ left` system message inserted in said conversations. This needs to be done in `wire-ios-data-model` when creating system message from update events (cf. `createOrUpdateMessageFromUpdateEvent` in `ZMMessage.m:854`).