### PR TITLE
Refetch team in case the selfUser joined

### DIFF
--- a/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
+++ b/Source/Transcoders/TeamDownloadRequestStrategy+Events.swift
@@ -89,16 +89,18 @@ extension TeamDownloadRequestStrategy: ZMEventConsumer {
              Team.fetchOrCreate(with: identifier, create: true, in: managedObjectContext, created: $0)
         }
         guard let team = fetchedTeam else { return }
-        // In case we just created this team locally, we want to ensure that we refetch all of its
-        // metadata, as well as all member permissions.
-        team.needsToBeUpdatedFromBackend = created
-        // cf. https://github.com/wireapp/architecture/issues/13
-        // We want to refetch the members in case we didn't just create the team as the payload does not include permissions.
-        team.needsToRedownloadMembers = !created
         guard let addedUserId = (data[TeamEventPayloadKey.user.rawValue] as? String).flatMap(UUID.init) else { return }
         guard let user = ZMUser(remoteID: addedUserId, createIfNeeded: true, in: managedObjectContext) else { return }
         user.needsToBeUpdatedFromBackend = true
         _ = Member.getOrCreateMember(for: user, in: team, context: managedObjectContext)
+
+        // In case we just created this team locally or the self user got added,
+        // we want to ensure that we refetch all of its metadata, as well as all member permissions.
+        team.needsToBeUpdatedFromBackend = created || user.isSelfUser
+
+        // cf. https://github.com/wireapp/architecture/issues/13
+        // We want to refetch the members in case we didn't just create the team as the payload does not include permissions.
+        team.needsToRedownloadMembers = !team.needsToBeUpdatedFromBackend
     }
 
     private func processRemovedMember(with event: ZMUpdateEvent) {


### PR DESCRIPTION
# What's in this PR?

* Always refetch a team in case the self user just joined.