### PR TITLE
Add notification fetch status to app.-status and don't create request while in progress

### DIFF
--- a/Source/Helpers/ApplicationStatus.swift
+++ b/Source/Helpers/ApplicationStatus.swift
@@ -49,6 +49,6 @@ public protocol ApplicationStatus : class {
     var requestCancellation : ZMRequestCancellation { get }
     var deliveryConfirmation : DeliveryConfirmationDelegate { get }
 
-    var notificationFetchStatus: BackgroundNotificationFetchStatusProvider { get }
+    var notificationFetchStatus: BackgroundNotificationFetchStatus { get }
 
 }

--- a/Source/Helpers/ApplicationStatus.swift
+++ b/Source/Helpers/ApplicationStatus.swift
@@ -19,6 +19,14 @@
 import Foundation
 import WireRequestStrategy
 
+@objc public protocol BackgroundNotificationFetchStatusProvider {
+    var status: BackgroundNotificationFetchStatus { get }
+}
+
+@objc public enum BackgroundNotificationFetchStatus: UInt8 {
+    case done, inProgress
+}
+
 @objc(ZMSynchronizationState)
 public enum SynchronizationState : UInt {
     case unauthenticated
@@ -40,4 +48,7 @@ public protocol ApplicationStatus : class {
     var clientRegistrationDelegate : ClientRegistrationDelegate { get }
     var requestCancellation : ZMRequestCancellation { get }
     var deliveryConfirmation : DeliveryConfirmationDelegate { get }
+
+    var notificationFetchStatus: BackgroundNotificationFetchStatusProvider { get }
+
 }

--- a/Source/Transcoders/AbstractRequestStrategy.swift
+++ b/Source/Transcoders/AbstractRequestStrategy.swift
@@ -26,7 +26,7 @@ open class AbstractRequestStrategy : NSObject, RequestStrategy {
     weak var applicationStatus : ApplicationStatus?
     
     public let managedObjectContext : NSManagedObjectContext
-    public var configuration : ZMStrategyConfigurationOption = [.allowsRequestsDuringEventProcessing]
+    public var configuration : ZMStrategyConfigurationOption = [.allowsRequestsDuringEventProcessing, .allowsRequestsDuringNotificationStreamFetch]
     
     public init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         self.managedObjectContext = managedObjectContext
@@ -72,7 +72,11 @@ open class AbstractRequestStrategy : NSObject, RequestStrategy {
         if applicationStatus.operationState == .background {
             prerequisites.insert(.allowsRequestsWhileInBackground)
         }
-        
+
+        if applicationStatus.notificationFetchStatus == .inProgress {
+            prerequisites.insert(.allowsRequestsDuringNotificationStreamFetch)
+        }
+
         return prerequisites
     }
 

--- a/Source/Transcoders/AbstractRequestStrategy.swift
+++ b/Source/Transcoders/AbstractRequestStrategy.swift
@@ -74,6 +74,9 @@ open class AbstractRequestStrategy : NSObject, RequestStrategy {
         }
 
         if applicationStatus.notificationFetchStatus == .inProgress {
+            // Don't create requests while we are still fetching the notification stream in the background.
+            // Otherwise we risk already sending out OTR messages when we have to fetch
+            // multiple pages of the stream (in case we have been offline for a while).
             prerequisites.insert(.allowsRequestsDuringNotificationStreamFetch)
         }
 

--- a/Source/Transcoders/AssetClientMessageRequestStrategy.swift
+++ b/Source/Transcoders/AssetClientMessageRequestStrategy.swift
@@ -40,6 +40,7 @@ public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, Z
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         assetAnalytics = AssetAnalytics(managedObjectContext: managedObjectContext)
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
+        configuration = .allowsRequestsDuringEventProcessing
 
         upstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,

--- a/Source/Transcoders/AssetV3DownloadRequestStrategy.swift
+++ b/Source/Transcoders/AssetV3DownloadRequestStrategy.swift
@@ -45,6 +45,8 @@ fileprivate let zmLog = ZMSLog(tag: "Asset V3")
             return asset.hasUploaded() && asset.uploaded.hasAssetId()
         }
 
+        configuration = .allowsRequestsDuringEventProcessing
+
         self.assetDownstreamObjectSync = ZMDownstreamObjectSync(
             transcoder: self,
             entityName: ZMAssetClientMessage.entityName(),

--- a/Source/Transcoders/AssetV3FileUploadRequestStrategy.swift
+++ b/Source/Transcoders/AssetV3FileUploadRequestStrategy.swift
@@ -75,7 +75,8 @@ public final class AssetV3FileUploadRequestStrategy: AbstractRequestStrategy, ZM
         assetAnalytics = AssetAnalytics(managedObjectContext: managedObjectContext)
 
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        
+        configuration = .allowsRequestsDuringEventProcessing
+
         upstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,
             entityName: ZMAssetClientMessage.entityName(),

--- a/Source/Transcoders/ClientMessageTranscoder.swift
+++ b/Source/Transcoders/ClientMessageTranscoder.swift
@@ -52,7 +52,7 @@ public class ClientMessageTranscoder: AbstractRequestStrategy {
         // Don't create requests while we are still fetching the notification stream in the background.
         // Otherwise we risk already sending out delivery receipts for received messages when we have to fetch
         // multiple pages of the stream (in case we have been offline for a while).
-        guard applicationStatus?.notificationFetchStatus.status == .done else { return nil }
+        guard applicationStatus?.notificationFetchStatus == .done else { return nil }
         return self.upstreamObjectSync.nextRequest()
     }
 }

--- a/Source/Transcoders/ClientMessageTranscoder.swift
+++ b/Source/Transcoders/ClientMessageTranscoder.swift
@@ -49,6 +49,10 @@ public class ClientMessageTranscoder: AbstractRequestStrategy {
     }
     
     public override func nextRequestIfAllowed() -> ZMTransportRequest? {
+        // Don't create requests while we are still fetching the notification stream in the background.
+        // Otherwise we risk already sending out delivery receipts for received messages when we have to fetch
+        // multiple pages of the stream (in case we have been offline for a while).
+        guard applicationStatus?.notificationFetchStatus.status == .done else { return nil }
         return self.upstreamObjectSync.nextRequest()
     }
 }

--- a/Source/Transcoders/ClientMessageTranscoder.swift
+++ b/Source/Transcoders/ClientMessageTranscoder.swift
@@ -49,10 +49,6 @@ public class ClientMessageTranscoder: AbstractRequestStrategy {
     }
     
     public override func nextRequestIfAllowed() -> ZMTransportRequest? {
-        // Don't create requests while we are still fetching the notification stream in the background.
-        // Otherwise we risk already sending out delivery receipts for received messages when we have to fetch
-        // multiple pages of the stream (in case we have been offline for a while).
-        guard applicationStatus?.notificationFetchStatus == .done else { return nil }
         return self.upstreamObjectSync.nextRequest()
     }
 }

--- a/Source/Transcoders/FetchingClientRequestStrategy.swift
+++ b/Source/Transcoders/FetchingClientRequestStrategy.swift
@@ -57,7 +57,7 @@ public final class FetchingClientRequestStrategy : AbstractRequestStrategy, ZMEv
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
-        self.configuration = [.allowsRequestsDuringEventProcessing]
+        self.configuration = [.allowsRequestsDuringEventProcessing, .allowsRequestsDuringNotificationStreamFetch]
         
         self.userClientsSync = ZMRemoteIdentifierObjectSync(transcoder: self, managedObjectContext: self.managedObjectContext)
         

--- a/Source/Transcoders/LinkPreviewAssetUploadRequestStrategy.swift
+++ b/Source/Transcoders/LinkPreviewAssetUploadRequestStrategy.swift
@@ -87,7 +87,7 @@ public final class LinkPreviewAssetUploadRequestStrategy : AbstractRequestStrate
         self.previewImagePreprocessor = previewImagePreprocessor ?? ZMImagePreprocessingTracker.createPreviewImagePreprocessingTracker(managedObjectContext: managedObjectContext)
         
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-        
+
         self.assetUpstreamSync = ZMUpstreamModifiedObjectSync(
             transcoder: self,
             entityName: ZMClientMessage.entityName(),

--- a/Source/Transcoders/MissingClientsRequestStrategy.swift
+++ b/Source/Transcoders/MissingClientsRequestStrategy.swift
@@ -52,7 +52,11 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
     public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
         
-        self.configuration =  [.allowsRequestsDuringEventProcessing, .allowsRequestsWhileInBackground]
+        self.configuration =  [
+            .allowsRequestsDuringEventProcessing,
+            .allowsRequestsWhileInBackground,
+            .allowsRequestsDuringNotificationStreamFetch
+        ]
         self.modifiedSync = ZMUpstreamModifiedObjectSync(transcoder: self, entityName: UserClient.entityName(), update: modifiedPredicate(), filter: nil, keysToSync: [ZMUserClientMissingKey], managedObjectContext: managedObjectContext)
     }
     

--- a/Source/ZMStrategyConfigurationOption.h
+++ b/Source/ZMStrategyConfigurationOption.h
@@ -22,4 +22,5 @@ typedef NS_OPTIONS(NSUInteger, ZMStrategyConfigurationOption) {
     ZMStrategyConfigurationOptionAllowsRequestsWhileInBackground = 1 << 1,
     ZMStrategyConfigurationOptionAllowsRequestsDuringSync = 1 << 2,
     ZMStrategyConfigurationOptionAllowsRequestsDuringEventProcessing = 1 << 3,
+    ZMStrategyConfigurationOptionAllowsRequestsDuringNotificationStreamFetch = 1 << 4
 };

--- a/Tests/Source/ClientMessageTrancoderTests+MessageConfirmation.swift
+++ b/Tests/Source/ClientMessageTrancoderTests+MessageConfirmation.swift
@@ -72,14 +72,13 @@ extension ClientMessageTranscoderTests {
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
 
             // When
-            self.mockApplicationStatus.mockNotificationFetchStatus.status = .inProgress
+            self.mockApplicationStatus.notificationFetchStatus = .inProgress
 
             // Then
             XCTAssertNil(self.sut.nextRequest())
 
             // When
-            self.mockApplicationStatus.mockNotificationFetchStatus.status = .done
-
+            self.mockApplicationStatus.notificationFetchStatus = .done
             // Then
             guard let request = self.sut.nextRequest() else { return XCTFail() }
 

--- a/Tests/Source/ClientMessageTrancoderTests+MessageConfirmation.swift
+++ b/Tests/Source/ClientMessageTrancoderTests+MessageConfirmation.swift
@@ -60,6 +60,34 @@ extension ClientMessageTranscoderTests {
             XCTAssertTrue(message.hasConfirmation())
         }
     }
+
+    func testThatItDoesNotSendAnyConfirmationWhenItIsStillFetchingNotificationsInTheBackground() {
+        syncMOC.performGroupedBlockAndWait {
+
+            // Given
+            let event = self.decryptedUpdateEventFromOtherClient(text: "foo", conversation: self.oneToOneConversation)
+            self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)
+            self.syncMOC.saveOrRollback()
+            guard let confirmationMessage = self.lastConfirmationMessage else { return XCTFail() }
+            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
+
+            // When
+            self.mockApplicationStatus.mockNotificationFetchStatus.status = .inProgress
+
+            // Then
+            XCTAssertNil(self.sut.nextRequest())
+
+            // When
+            self.mockApplicationStatus.mockNotificationFetchStatus.status = .done
+
+            // Then
+            guard let request = self.sut.nextRequest() else { return XCTFail() }
+
+            // THEN
+            guard let message = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else { return XCTFail() }
+            XCTAssertTrue(message.hasConfirmation())
+        }
+    }
     
     func testThatItDeletesTheConfirmationMessageWhenSentSuccessfully() {
         

--- a/Tests/Source/Helpers/MockObjects.swift
+++ b/Tests/Source/Helpers/MockObjects.swift
@@ -23,6 +23,7 @@ import WireMessageStrategy
 import WireDataModel
 
 public class MockApplicationStatus : NSObject, ApplicationStatus {
+
     
     public var deliveryConfirmation: DeliveryConfirmationDelegate {
         return self.mockConfirmationStatus
@@ -36,11 +37,8 @@ public class MockApplicationStatus : NSObject, ApplicationStatus {
         return self.mockClientRegistrationStatus
     }
 
-    public var notificationFetchStatus: BackgroundNotificationFetchStatusProvider {
-        return mockNotificationFetchStatus
-    }
+    public var notificationFetchStatus = BackgroundNotificationFetchStatus.done
 
-    public let mockNotificationFetchStatus = MockNotificationFetchStatusProvider()
     public let mockConfirmationStatus = MockConfirmationStatus()
     public let mockTaskCancellationDelegate = MockTaskCancellationDelegate()
     public var mockClientRegistrationStatus = MockClientRegistrationStatus()
@@ -82,12 +80,6 @@ public class MockTaskCancellationDelegate: NSObject, ZMRequestCancellation {
     public func cancelTask(with identifier: ZMTaskIdentifier) {
         cancelledIdentifiers.append(identifier)
     }
-}
-
-public final class MockNotificationFetchStatusProvider: BackgroundNotificationFetchStatusProvider {
-
-    public var status: BackgroundNotificationFetchStatus = .done
-
 }
 
 

--- a/Tests/Source/Helpers/MockObjects.swift
+++ b/Tests/Source/Helpers/MockObjects.swift
@@ -35,7 +35,12 @@ public class MockApplicationStatus : NSObject, ApplicationStatus {
     public var clientRegistrationDelegate : ClientRegistrationDelegate {
         return self.mockClientRegistrationStatus
     }
-    
+
+    public var notificationFetchStatus: BackgroundNotificationFetchStatusProvider {
+        return mockNotificationFetchStatus
+    }
+
+    public let mockNotificationFetchStatus = MockNotificationFetchStatusProvider()
     public let mockConfirmationStatus = MockConfirmationStatus()
     public let mockTaskCancellationDelegate = MockTaskCancellationDelegate()
     public var mockClientRegistrationStatus = MockClientRegistrationStatus()
@@ -77,6 +82,12 @@ public class MockTaskCancellationDelegate: NSObject, ZMRequestCancellation {
     public func cancelTask(with identifier: ZMTaskIdentifier) {
         cancelledIdentifiers.append(identifier)
     }
+}
+
+public final class MockNotificationFetchStatusProvider: BackgroundNotificationFetchStatusProvider {
+
+    public var status: BackgroundNotificationFetchStatus = .done
+
 }
 
 

--- a/Tests/Source/LinkPreviewUploadRequestStrategyTests.swift
+++ b/Tests/Source/LinkPreviewUploadRequestStrategyTests.swift
@@ -24,12 +24,13 @@ import WireTransport
 class LinkPreviewUploadRequestStrategyTests: MessagingTestBase {
 
     private var sut: LinkPreviewUploadRequestStrategy!
-    private var authStatus: MockClientRegistrationStatus!
+    private var applicationStatus: MockApplicationStatus!
 
     override func setUp() {
         super.setUp()
-        authStatus = MockClientRegistrationStatus()
-        sut = LinkPreviewUploadRequestStrategy(managedObjectContext: syncMOC, clientRegistrationDelegate: authStatus)
+        applicationStatus = MockApplicationStatus()
+        applicationStatus.mockSynchronizationState = .eventProcessing
+        sut = LinkPreviewUploadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: applicationStatus)
     }
 
     func testThatItDoesNotCreateARequestInState_Done() {


### PR DESCRIPTION
# What's in this PR?

* We now query if we are currently fetching the notification stream as response to receiving a push notification before creating requests in the client message transcoder.
* Fix `LinkPreviewUploadRequestStrategy` generating events during sync.