### PR TITLE
Mark message as failed to send when no request can be generated

### DIFF
--- a/Tests/Source/ClientMessageTranscoderTests.swift
+++ b/Tests/Source/ClientMessageTranscoderTests.swift
@@ -136,6 +136,32 @@ extension ClientMessageTranscoderTests {
         }
     }
     
+    func testThatItDoesNotGenerateARequestToSendAClientMessageIfNoRecepientsGiven() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            conversation.conversationType = .group
+            conversation.remoteIdentifier = UUID.create()
+            self.syncMOC.saveOrRollback()
+            
+            conversation.updateMessageDestructionTimeout(timeout: ZMConversationMessageDestructionTimeout.fifteenSeconds)
+            let message = conversation.appendMessage(withText: "Hello world") as! ZMClientMessage
+            self.syncMOC.saveOrRollback()
+            
+            // WHEN
+            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
+            self.performIgnoringZMLogError {
+                if let _ = self.sut.nextRequest() {
+                    XCTFail()
+                    return
+                }
+            }
+            
+            // THEN
+            XCTAssertTrue(message.isExpired)
+        }
+    }
+    
     func testThatItGeneratesARequestToSendAClientMessageExternalWithExternalBlob() {
         self.syncMOC.performGroupedBlockAndWait {
             

--- a/Tests/Source/ClientMessageTranscoderTests.swift
+++ b/Tests/Source/ClientMessageTranscoderTests.swift
@@ -151,10 +151,7 @@ extension ClientMessageTranscoderTests {
             // WHEN
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
             self.performIgnoringZMLogError {
-                if let _ = self.sut.nextRequest() {
-                    XCTFail()
-                    return
-                }
+                XCTAssertNil(self.sut.nextRequest())
             }
             
             // THEN


### PR DESCRIPTION
# Issue

Sending the ephemeral message in the empty conversation causes the crash loop, while there are no recipients to the message.

Depends on https://github.com/wireapp/wire-ios-data-model/pull/311