### PR TITLE
don’t filter out message events from web socket

### DIFF
--- a/Source/Transcoders/ClientMessageTranscoder.swift
+++ b/Source/Transcoders/ClientMessageTranscoder.swift
@@ -118,7 +118,7 @@ extension ClientMessageTranscoder {
                 }
             }
             
-            if let updateMessage = updateResult.message, event.source == .pushNotification {
+            if let updateMessage = updateResult.message, event.source == .pushNotification || event.source == .webSocket {
                 if let genericMessage = ZMGenericMessage(from: event) {
                     self.localNotificationDispatcher.process(genericMessage)
                 }


### PR DESCRIPTION
We want to pass all message notifications to the local notification dispatcher in order to generate custom in app chat heads.